### PR TITLE
.NET 9 update

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ defaults:
     shell: pwsh
 
 env:
-  DOTNET_VERSION: 8.x
+  DOTNET_VERSION: 9.x
 
 jobs:
   build:

--- a/Templates.csproj
+++ b/Templates.csproj
@@ -2,13 +2,13 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.7.6</PackageVersion>
+    <PackageVersion>1.8.0</PackageVersion>
     <PackageId>Keboo.Dotnet.Templates</PackageId>
     <Title>Keboo's .NET Templates</Title>
     <Authors>Keboo</Authors>
     <Description>.NET Templates built by Keboo</Description>
     <PackageTags>Template;WPF;NuGet;Console</PackageTags>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <RepositoryUrl>https://github.com/Keboo/DotnetTemplates</RepositoryUrl>
     <PackageIcon>NuGetIcon.png</PackageIcon>

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/ServiceCollectionExtensions.cs
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/ServiceCollectionExtensions.cs
@@ -47,6 +47,7 @@ public static class ServiceCollectionExtensions
         where TViewModel : class
     {
         services.AddTransient<TViewModel>();
+        services.AddSingleton<Func<TViewModel>>(sp => () => sp.GetRequiredService<TViewModel>());
         services.AddTransient<TView>();
     }
 }

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/Views/MainView.axaml.cs
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/Views/MainView.axaml.cs
@@ -12,10 +12,21 @@ public partial class MainView : UserControl
         InitializeComponent();
     }
 
+    private Func<MainViewModel>? ViewModelAccessor { get; }
+
     // This constructor is used when the view is created via dependency injection
-    public MainView(MainViewModel viewModel)
+    public MainView(Func<MainViewModel> viewModelAccessor)
         : this()
     {
-        DataContext = viewModel;
+        ViewModelAccessor = viewModelAccessor;
+    }
+
+    protected override void OnLoaded(RoutedEventArgs e)
+    {
+        base.OnLoaded(e);
+        // NB: This intentionally defers creating the view model until after the main view is loaded.
+        // This is needed when the view model takes a dependency that requires the application lifetime to initialized.
+        // Such as the IStorageProvider.
+        DataContext = ViewModelAccessor?.Invoke();
     }
 }

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/Views/MainView.axaml.cs
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/Views/MainView.axaml.cs
@@ -1,4 +1,5 @@
 ﻿using Avalonia.Controls;
+using Avalonia.Interactivity;
 
 using SampleAvaloniaApplication.ViewModels;
 

--- a/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
+++ b/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/templates/Console/ConsoleApp/ConsoleApp/ConsoleApp.csproj
+++ b/templates/Console/ConsoleApp/ConsoleApp/ConsoleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <Version>0.0.1</Version>
   </PropertyGroup>
 

--- a/templates/Library/NuGet/NuGetLib.Tests/NuGetLib.Tests.csproj
+++ b/templates/Library/NuGet/NuGetLib.Tests/NuGetLib.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>

--- a/templates/Library/NuGet/NuGetLib/NuGetLib.csproj
+++ b/templates/Library/NuGet/NuGetLib/NuGetLib.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup Label="NuGet">

--- a/templates/WPF/WpfApp/WpfApp.Tests/WpfApp.Tests.csproj
+++ b/templates/WPF/WpfApp/WpfApp.Tests/WpfApp.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
 
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>

--- a/templates/WPF/WpfApp/WpfApp/WpfApp.csproj
+++ b/templates/WPF/WpfApp/WpfApp/WpfApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
 
     <UseWPF>true</UseWPF>
     <StartupObject>WpfApp.App</StartupObject>


### PR DESCRIPTION
Updates the .NET templates to target .NET 9.0.

Increases the package version and modifies the Avalonia template to defer view model creation until after the view is loaded, addressing potential issues with dependencies that require application lifetime initialization, such as IStorageProvider.
