### PR TITLE
Switch MSTest templates to MSTest.Sdk 4.1.0

### DIFF
--- a/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
+++ b/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
@@ -1,29 +1,35 @@
+<!--#if (tests == "mstest")-->
+<!-- MSTest.Sdk docs:
+     https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-getting-started
+     https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-sdk#extend-microsofttestingplatform
+-->
+<Project Sdk="MSTest.Sdk/4.1.0">
+<!--#else-->
 <Project Sdk="Microsoft.NET.Sdk">
+<!--#endif-->
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-<!--#if (tests == "tunit" || tests == "mstest")-->
+<!--#if (tests == "tunit")-->
     <OutputType>Exe</OutputType>
 <!--#endif-->
 <!--#if (tests == "mstest")-->
-    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingExtensionsProfile>AllMicrosoft</TestingExtensionsProfile>
 <!--#endif-->
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
+<!--#if (tests != "mstest")-->
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+<!--#endif-->
     <PackageReference Include="Moq" />
     <PackageReference Include="Moq.AutoMock" />
     <PackageReference Include="System.CommandLine" />
 <!--#if (tests == "xunit")-->
     <PackageReference Include="xunit.v3.mtp-v2" />
-<!--#endif-->
-<!--#if (tests == "mstest")-->
-    <PackageReference Include="MSTest.TestAdapter" />
-    <PackageReference Include="MSTest.TestFramework" />
 <!--#endif-->
 <!--#if (tests == "tunit")-->
     <PackageReference Include="TUnit" />

--- a/templates/Console/ConsoleApp/Directory.Packages.props
+++ b/templates/Console/ConsoleApp/Directory.Packages.props
@@ -25,8 +25,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <PackageVersion Include="TUnit" Version="1.22.6" />
     <PackageVersion Include="TUnit.Assertions" Version="1.22.6" />

--- a/templates/Library/NuGet/Directory.Packages.props
+++ b/templates/Library/NuGet/Directory.Packages.props
@@ -24,8 +24,6 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.201" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageVersion Include="TUnit" Version="1.22.6" />
     <PackageVersion Include="TUnit.Assertions" Version="1.22.6" />
     <PackageVersion Include="TUnit.Engine" Version="1.22.6" />

--- a/templates/Library/NuGet/NuGetLib.Tests/NuGetLib.Tests.csproj
+++ b/templates/Library/NuGet/NuGetLib.Tests/NuGetLib.Tests.csproj
@@ -1,12 +1,20 @@
+<!--#if (tests == "mstest")-->
+<!-- MSTest.Sdk docs:
+     https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-getting-started
+     https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-sdk#extend-microsofttestingplatform
+-->
+<Project Sdk="MSTest.Sdk/4.1.0">
+<!--#else-->
 <Project Sdk="Microsoft.NET.Sdk">
+<!--#endif-->
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-<!--#if (tests == "tunit" || tests == "mstest")-->
+<!--#if (tests == "tunit")-->
     <OutputType>Exe</OutputType>
 <!--#endif-->
 <!--#if (tests == "mstest")-->
-    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingExtensionsProfile>AllMicrosoft</TestingExtensionsProfile>
 <!--#endif-->
     <IsPublishable>false</IsPublishable>
     <IsPackable>false</IsPackable>
@@ -14,16 +22,14 @@
   </PropertyGroup>
 
   <ItemGroup>
+<!--#if (tests != "mstest")-->
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+<!--#endif-->
     <PackageReference Include="Moq" />
     <PackageReference Include="Moq.AutoMock" />
 <!--#if (tests == "xunit")-->
     <PackageReference Include="xunit.v3.mtp-v2" />
-<!--#endif-->
-<!--#if (tests == "mstest")-->
-    <PackageReference Include="MSTest.TestAdapter" />
-    <PackageReference Include="MSTest.TestFramework" />
 <!--#endif-->
 <!--#if (tests == "tunit")-->
     <PackageReference Include="TUnit" />

--- a/templates/WPF/WpfApp/Directory.Packages.props
+++ b/templates/WPF/WpfApp/Directory.Packages.props
@@ -29,8 +29,6 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.1" />
-    <PackageVersion Include="MSTest.TestAdapter" Version="4.1.0" />
-    <PackageVersion Include="MSTest.TestFramework" Version="4.1.0" />
     <PackageVersion Include="System.Text.Json" Version="10.0.5" />
     <PackageVersion Include="TUnit" Version="1.22.6" />
     <PackageVersion Include="TUnit.Assertions" Version="1.22.6" />

--- a/templates/WPF/WpfApp/WpfApp.Tests/WpfApp.Tests.csproj
+++ b/templates/WPF/WpfApp/WpfApp.Tests/WpfApp.Tests.csproj
@@ -1,12 +1,20 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<!--#if (tests == "mstest")-->
+<!-- MSTest.Sdk docs:
+     https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-getting-started
+     https://learn.microsoft.com/dotnet/core/testing/unit-testing-mstest-sdk#extend-microsofttestingplatform
+-->
+<Project Sdk="MSTest.Sdk/4.1.0">
+<!--#else-->
+<Project Sdk="Microsoft.NET.Sdk">
+<!--#endif-->
 
   <PropertyGroup>
     <TargetFramework>net10.0-windows</TargetFramework>
-<!--#if (tests == "tunit" || tests == "mstest")-->
+<!--#if (tests == "tunit")-->
     <OutputType>exe</OutputType>
 <!--#endif-->
 <!--#if (tests == "mstest")-->
-    <EnableMSTestRunner>true</EnableMSTestRunner>
+    <TestingExtensionsProfile>AllMicrosoft</TestingExtensionsProfile>
 <!--#endif-->
 
     <IsPublishable>false</IsPublishable>
@@ -17,18 +25,16 @@
   </PropertyGroup>
 
   <ItemGroup>
+<!--#if (tests != "mstest")-->
     <PackageReference Include="Microsoft.Testing.Extensions.CodeCoverage" />
 <!--#if (tests != "tunit")-->
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
+<!--#endif-->
 <!--#endif-->
     <PackageReference Include="Moq" />
     <PackageReference Include="Moq.AutoMock" />
 <!--#if (tests == "xunit")-->
     <PackageReference Include="xunit.v3.mtp-v2" />
-<!--#endif-->
-<!--#if (tests == "mstest")-->
-    <PackageReference Include="MSTest.TestAdapter" />
-    <PackageReference Include="MSTest.TestFramework" />
 <!--#endif-->
 <!--#if (tests == "tunit")-->
     <PackageReference Include="TUnit" />


### PR DESCRIPTION
## Why
The MSTest-backed templates were still generating test projects with the older `MSTest.TestAdapter` / `MSTest.TestFramework` package pair. This updates them to the SDK-based setup so new projects get the current MSTest configuration while keeping the MSTest docs links visible in the generated `.csproj` files.

## What changed
- Switch the Console, Library, and WPF MSTest variants to `MSTest.Sdk/4.1.0`
- Default `TestingExtensionsProfile` to `AllMicrosoft`
- Keep MSTest documentation links in the MSTest `.csproj` variants
- Remove the legacy MSTest package entries from the affected `Directory.Packages.props` files

## Notes
- This only changes the MSTest variants; xUnit and TUnit stay on their existing setup.
- Credit: [BenjaminMichaelis](https://github.com/BenjaminMichaelis)