### PR TITLE
Add retry guidance to test workflows

### DIFF
--- a/templates/Aspire/ReactApp/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/ReactApp/.github/workflows/build-and-deploy.yml
@@ -81,6 +81,9 @@ jobs:
 
       # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
       # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
+      # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
+      # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
+      # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
       - name: Test
         run: dotnet test --no-build --configuration Release --verbosity normal --maximum-failed-tests 10
 

--- a/templates/Console/ConsoleApp/.devops/build-and-test.yml
+++ b/templates/Console/ConsoleApp/.devops/build-and-test.yml
@@ -49,6 +49,9 @@ stages:
 
           # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
           # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
+          # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
+          # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
+          # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
           - task: DotNetCoreCLI@2
             displayName: 'dotnet test'
             inputs:

--- a/templates/Console/ConsoleApp/.github/workflows/build-and-deploy.yml
+++ b/templates/Console/ConsoleApp/.github/workflows/build-and-deploy.yml
@@ -31,6 +31,9 @@ jobs:
 
       # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
       # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
+      # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
+      # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
+      # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
       - name: dotnet test
         run: dotnet test --configuration Release --no-build --maximum-failed-tests 10 -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
 

--- a/templates/Library/NuGet/.devops/build-and-deploy.yml
+++ b/templates/Library/NuGet/.devops/build-and-deploy.yml
@@ -51,6 +51,9 @@ stages:
 #if (!no-tests)
           # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
           # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
+          # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
+          # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
+          # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
           - task: DotNetCoreCLI@2
             displayName: 'dotnet test'
             inputs:

--- a/templates/Library/NuGet/.github/workflows/build-and-deploy.yml
+++ b/templates/Library/NuGet/.github/workflows/build-and-deploy.yml
@@ -31,6 +31,9 @@ jobs:
 #if (!no-tests)
       # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
       # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
+      # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
+      # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
+      # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
       - name: dotnet test
         run: dotnet test --configuration Release --no-build --maximum-failed-tests 10 -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
 

--- a/templates/WPF/WpfApp/.devops/build-app.yml
+++ b/templates/WPF/WpfApp/.devops/build-app.yml
@@ -43,6 +43,9 @@ stages:
 
           # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
           # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
+          # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
+          # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
+          # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
           - task: DotNetCoreCLI@2
             displayName: 'dotnet test'
             inputs:

--- a/templates/WPF/WpfApp/.github/workflows/build_app.yml
+++ b/templates/WPF/WpfApp/.github/workflows/build_app.yml
@@ -33,6 +33,9 @@ jobs:
 
       # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
       # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
+      # To enable retries, add Microsoft.Testing.Extensions.Retry to the test project, then pass
+      # --retry-failed-tests plus --retry-failed-tests-max-percentage <value> to skip reruns when too many tests fail:
+      # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-retry#retry-1
       - name: dotnet test
         run: dotnet test --configuration Release --no-build --maximum-failed-tests 10 -- --coverage --coverage-output-format cobertura --coverage-output coverage.cobertura.xml
         


### PR DESCRIPTION
## Summary
- add retry guidance comments to the test-running GitHub Actions and Azure DevOps template YAML files
- call out `--retry-failed-tests-max-percentage` and link to the Microsoft Testing Platform retry docs

Credit to @BenjaminMichaelis for the retry guidance suggestion.