### PR TITLE
Set TUnit as the default test framework

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@ This repository provides opinionated .NET project templates packaged as a NuGet 
 **Template Parameters Pattern:**
 All templates share common parameters:
 - `no-sln` - Exclude solution files
-- `tests` - Choose testing framework: "xunit" (default), "mstest", "tunit", or "none"
+- `tests` - Choose testing framework: "tunit" (default), "xunit", "mstest", or "none"
 - `sln` - Use legacy .sln instead of modern .slnx format
 - `pipeline` - Choice between "github" or "azuredevops" CI/CD
 - Auto-generated symbols: `user_secrets_id` (GUID), `createdDate` (year)

--- a/templates/Aspire/ReactApp/README.md
+++ b/templates/Aspire/ReactApp/README.md
@@ -16,7 +16,8 @@ Create a new app in your current directory by running.
 |-----------|-------------|---------|
 | `--pipeline` | CI/CD provider to use. Options: `github`, `azuredevops`, `none` | `github` |
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
-| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `xunit` |
+
+This template includes TUnit-based test projects by default.
 
 **Example with Azure DevOps:**
 ```cli
@@ -33,15 +34,6 @@ Create a new app in your current directory by running.
 > dotnet new keboo.blazor --sln true
 ```
 
-**Example with MSTest:**
-```cli
-> dotnet new keboo.blazor --tests mstest
-```
-
-**Example with no tests:**
-```cli
-> dotnet new keboo.blazor --tests none
-```
 
 ## Updating .NET Version
 

--- a/templates/Avalonia/AvaloniaSolution/.template.config/template.json
+++ b/templates/Avalonia/AvaloniaSolution/.template.config/template.json
@@ -66,7 +66,7 @@
           "description": "Do not include tests"
         }
       ],
-      "defaultValue": "xunit",
+      "defaultValue": "tunit",
       "description": "The testing framework to use"
     },
     "useXunit": {

--- a/templates/Avalonia/AvaloniaSolution/README.md
+++ b/templates/Avalonia/AvaloniaSolution/README.md
@@ -15,7 +15,7 @@ Create a new app in your current directory by running.
 | Parameter | Description | Default |
 |-----------|-------------|---------|
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
-| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `xunit` |
+| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |
 
 **Example with legacy .sln format:**
 ```cli

--- a/templates/Console/ConsoleApp/.template.config/template.json
+++ b/templates/Console/ConsoleApp/.template.config/template.json
@@ -75,7 +75,7 @@
           "description": "Do not include tests"
         }
       ],
-      "defaultValue": "xunit",
+      "defaultValue": "tunit",
       "description": "The testing framework to use"
     },
     "useXunit": {

--- a/templates/Console/ConsoleApp/README.md
+++ b/templates/Console/ConsoleApp/README.md
@@ -16,7 +16,7 @@ Create a new app in your current directory by running.
 |-----------|-------------|---------|
 | `--pipeline` | CI/CD provider to use. Options: `github`, `azuredevops`, `none` | `github` |
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
-| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `xunit` |
+| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |
 
 **Example with Azure DevOps:**
 ```cli

--- a/templates/Library/NuGet/.template.config/template.json
+++ b/templates/Library/NuGet/.template.config/template.json
@@ -75,7 +75,7 @@
           "description": "Do not include tests"
         }
       ],
-      "defaultValue": "xunit",
+      "defaultValue": "tunit",
       "description": "The testing framework to use"
     },
     "useXunit": {

--- a/templates/Library/NuGet/README.md
+++ b/templates/Library/NuGet/README.md
@@ -16,7 +16,7 @@ Create a new app in your current directory by running.
 |-----------|-------------|---------|
 | `--pipeline` | CI/CD provider to use. Options: `github`, `azuredevops`, `none` | `github` |
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
-| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `xunit` |
+| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |
 
 **Example with Azure DevOps:**
 ```cli

--- a/templates/WPF/WpfApp/.template.config/template.json
+++ b/templates/WPF/WpfApp/.template.config/template.json
@@ -67,7 +67,7 @@
           "description": "Do not include tests"
         }
       ],
-      "defaultValue": "xunit",
+      "defaultValue": "tunit",
       "description": "The testing framework to use"
     },
     "useXunit": {

--- a/templates/WPF/WpfApp/README.md
+++ b/templates/WPF/WpfApp/README.md
@@ -15,7 +15,7 @@ Create a new app in your current directory by running.
 |-----------|-------------|---------|
 | `--pipeline` | CI/CD provider to use. Options: `github`, `azuredevops`, `none` | `github` |
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
-| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `xunit` |
+| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |
 
 **Example with Azure DevOps:**
 ```cli


### PR DESCRIPTION
## Why
The configurable templates in this repo were still defaulting new projects to xUnit even though the desired default is now TUnit. That left newly scaffolded projects inconsistent across the template set and out of sync with the test setup already used by the Aspire React template.

## What changed
- switched the `tests` default from `xunit` to `tunit` in the Console, NuGet, WPF, and Avalonia template configs
- updated the matching template READMEs and the shared repo guidance to show `tunit` as the default
- corrected the Aspire React README so it describes the template's existing TUnit-based test projects instead of a `--tests` switch it does not expose

## Notes
- generated `keboo.console`, `keboo.nuget`, `keboo.wpf`, and `keboo.react` locally to confirm they now emit `TUnit` test projects by default
- `keboo.avalonia` still exposes a `--tests` option but currently has no test project content to emit; that is a pre-existing limitation and is unchanged in this PR