### PR TITLE
Fix README test command typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can now test the template by running:
 ```cli
 dotnet new keboo.wpf
 dotnet build
-dotent test --no-build
+dotnet test --no-build
 dotnet publish --no-build
 ```
 


### PR DESCRIPTION
The local testing instructions currently show `dotent test --no-build`, which is a typo. This updates the README to use the correct `dotnet test --no-build` command so the example is copy/pasteable.