### PR TITLE
Add MCP mode to the console template

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,9 @@
 # Dotnet Templates
 
-The repository contains a set of opinionated [dotnet new templates](https://learn.microsoft.com/dotnet/core/tools/custom-templates). I am happy to receive critique/feedback on the existing templates, so feel free to open issues.
+The repository contains a set of opinionated [dotnet new templates](https://learn.microsoft.com/dotnet/core/tools/custom-templates). I am happy to receive critique and feedback on the existing templates, so feel free to open issues.
 
 ## Installing
+
 Use [dotnet new install](https://learn.microsoft.com/dotnet/core/tools/dotnet-new-install) to install the templates.
 
 ```cli
@@ -10,34 +11,42 @@ dotnet new install Keboo.Dotnet.Templates
 ```
 
 ## Updating
-If you have previously installed the templates and want to install the latest version, you can use [dotnet new update](https://learn.microsoft.com/dotnet/core/tools/dotnet-new-update) to update your installed templates.
+
+If you have previously installed the templates and want the latest version, you can use [dotnet new update](https://learn.microsoft.com/dotnet/core/tools/dotnet-new-update).
+
 ```cli
 dotnet new update
 ```
 
-# Uninstalling
+## Uninstalling
+
 ```cli
 dotnet new uninstall Keboo.Dotnet.Templates
 ```
 
-## Included Templates 
+## Included templates
+
 - [Avalonia Solution](./templates/Avalonia/AvaloniaSolution/README.md)
 - [WPF Solution](./templates/WPF/WpfApp/README.md)
 - [NuGet Package Solution](./templates/Library/NuGet/README.md)
-- [System.CommandLine Solution](./templates/Console/ConsoleApp/README.md)
+- [System.CommandLine Solution](./templates/Console/ConsoleApp/README.md) - supports `--mcp` to scaffold a NuGet-hosted MCP server variant.
 
-# Local testing 
+## Local testing
+
 Build the template package:
+
 ```cli
 dotnet pack --configuration Release -o .
 ```
 
-Install the locally built template package
+Install the locally built template package:
+
 ```cli
 dotnet new install . --force
 ```
 
-You can now test the template by running:
+You can now test a template by running:
+
 ```cli
 dotnet new keboo.wpf
 dotnet build
@@ -45,7 +54,16 @@ dotnet test --no-build
 dotnet publish --no-build
 ```
 
-When done, you can remove the local install of the template package by running:
+You can also exercise the new console MCP option with:
+
+```cli
+dotnet new keboo.console --mcp
+dotnet test
+dotnet pack -c Release
+```
+
+When done, you can remove the local install of the template package:
+
 ```cli
 dotnet new uninstall .
 ```

--- a/templates/Console/ConsoleApp/.template.config/template.json
+++ b/templates/Console/ConsoleApp/.template.config/template.json
@@ -54,6 +54,12 @@
       "defaultValue": "false",
       "description": "Do not include a solution file."
     },
+    "mcp": {
+      "type": "parameter",
+      "dataType": "bool",
+      "defaultValue": "false",
+      "description": "Configure the app as a NuGet-hosted MCP server instead of a System.CommandLine CLI"
+    },
     "tests": {
       "type": "parameter",
       "dataType": "choice",
@@ -160,6 +166,12 @@
           "exclude": [
             "ConsoleApp.Tests/**",
             ".github/workflows/pr-code-coverage-comment.yml"
+          ]
+        },
+        {
+          "condition": "(!mcp)",
+          "exclude": [
+            "ConsoleApp/.mcp/**"
           ]
         },
         {

--- a/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
+++ b/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
@@ -7,7 +7,6 @@
 <!--#else-->
 <Project Sdk="Microsoft.NET.Sdk">
 <!--#endif-->
-
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
 <!--#if (tests == "tunit")-->
@@ -16,7 +15,6 @@
 <!--#if (tests == "mstest")-->
     <TestingExtensionsProfile>AllMicrosoft</TestingExtensionsProfile>
 <!--#endif-->
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
@@ -27,7 +25,9 @@
 <!--#endif-->
     <PackageReference Include="Moq" />
     <PackageReference Include="Moq.AutoMock" />
+<!--#if (!mcp)-->
     <PackageReference Include="System.CommandLine" />
+<!--#endif-->
 <!--#if (tests == "xunit")-->
     <PackageReference Include="xunit.v3.mtp-v2" />
 <!--#endif-->

--- a/templates/Console/ConsoleApp/ConsoleApp.Tests/ProgramTests.mstest.cs
+++ b/templates/Console/ConsoleApp/ConsoleApp.Tests/ProgramTests.mstest.cs
@@ -1,5 +1,33 @@
-using System.CommandLine;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+//#if (mcp)
+namespace ConsoleApp.Tests;
+
+[TestClass]
+public class ProgramTests
+{
+    [TestMethod]
+    public void Add_WithTwoNumbers_DisplaysResult()
+    {
+        MathTools tool = new();
+
+        string result = tool.Add(4, 2);
+
+        Assert.AreEqual("The result is 6", result);
+    }
+
+    [TestMethod]
+    public void Add_WithNegativeNumber_DisplaysResult()
+    {
+        MathTools tool = new();
+
+        string result = tool.Add(4, -2);
+
+        Assert.AreEqual("The result is 2", result);
+    }
+}
+//#else
+using System.CommandLine;
 
 namespace ConsoleApp.Tests;
 
@@ -11,7 +39,7 @@ public class ProgramTests
     {
         using StringWriter stdOut = new();
         int exitCode = await Invoke("--help", stdOut);
-        
+
         Assert.AreEqual(0, exitCode);
         Assert.IsTrue(stdOut.ToString().Contains("--help"));
     }
@@ -34,3 +62,4 @@ public class ProgramTests
         return parseResult.InvokeAsync();
     }
 }
+//#endif

--- a/templates/Console/ConsoleApp/ConsoleApp.Tests/ProgramTests.tunit.cs
+++ b/templates/Console/ConsoleApp/ConsoleApp.Tests/ProgramTests.tunit.cs
@@ -1,7 +1,34 @@
-using System.CommandLine;
 using TUnit.Assertions;
 using TUnit.Assertions.Extensions;
 using TUnit.Core;
+
+//#if (mcp)
+namespace ConsoleApp.Tests;
+
+public class ProgramTests
+{
+    [Test]
+    public async Task Add_WithTwoNumbers_DisplaysResult()
+    {
+        MathTools tool = new();
+
+        string result = tool.Add(4, 2);
+
+        await Assert.That(result).IsEqualTo("The result is 6");
+    }
+
+    [Test]
+    public async Task Add_WithNegativeNumber_DisplaysResult()
+    {
+        MathTools tool = new();
+
+        string result = tool.Add(4, -2);
+
+        await Assert.That(result).IsEqualTo("The result is 2");
+    }
+}
+//#else
+using System.CommandLine;
 
 namespace ConsoleApp.Tests;
 
@@ -12,7 +39,7 @@ public class ProgramTests
     {
         using StringWriter stdOut = new();
         int exitCode = await Invoke("--help", stdOut);
-        
+
         await Assert.That(exitCode).IsEqualTo(0);
         await Assert.That(stdOut.ToString()).Contains("--help");
     }
@@ -35,3 +62,4 @@ public class ProgramTests
         return parseResult.InvokeAsync();
     }
 }
+//#endif

--- a/templates/Console/ConsoleApp/ConsoleApp.Tests/ProgramTests.xunit.cs
+++ b/templates/Console/ConsoleApp/ConsoleApp.Tests/ProgramTests.xunit.cs
@@ -1,3 +1,29 @@
+//#if (mcp)
+namespace ConsoleApp.Tests;
+
+public class ProgramTests
+{
+    [Fact]
+    public void Add_WithTwoNumbers_DisplaysResult()
+    {
+        MathTools tool = new();
+
+        string result = tool.Add(4, 2);
+
+        Assert.Equal("The result is 6", result);
+    }
+
+    [Fact]
+    public void Add_WithNegativeNumber_DisplaysResult()
+    {
+        MathTools tool = new();
+
+        string result = tool.Add(4, -2);
+
+        Assert.Equal("The result is 2", result);
+    }
+}
+//#else
 using System.CommandLine;
 
 namespace ConsoleApp.Tests;
@@ -9,7 +35,7 @@ public class ProgramTests
     {
         using StringWriter stdOut = new();
         int exitCode = await Invoke("--help", stdOut);
-        
+
         Assert.Equal(0, exitCode);
         Assert.Contains("--help", stdOut.ToString());
     }
@@ -32,3 +58,4 @@ public class ProgramTests
         return parseResult.InvokeAsync();
     }
 }
+//#endif

--- a/templates/Console/ConsoleApp/ConsoleApp/.mcp/server.json
+++ b/templates/Console/ConsoleApp/ConsoleApp/.mcp/server.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-10-17/server.schema.json",
+  "description": "MCP server for ConsoleApp.",
+  "name": "io.github.<your-github-username>/ConsoleApp",
+  "version": "0.0.1",
+  "packages": [
+    {
+      "registryType": "nuget",
+      "registryBaseUrl": "https://api.nuget.org",
+      "identifier": "ConsoleApp",
+      "version": "0.0.1",
+      "transport": {
+        "type": "stdio"
+      },
+      "packageArguments": [],
+      "environmentVariables": []
+    }
+  ],
+  "repository": {
+    "url": "https://github.com/<your-github-username>/ConsoleApp",
+    "source": "github"
+  }
+}

--- a/templates/Console/ConsoleApp/ConsoleApp/ConsoleApp.csproj
+++ b/templates/Console/ConsoleApp/ConsoleApp/ConsoleApp.csproj
@@ -4,22 +4,83 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net10.0</TargetFramework>
     <Version>0.0.1</Version>
+<!--#if (mcp)-->
+    <!-- NuGet MCP packaging guidance:
+         https://learn.microsoft.com/nuget/concepts/nuget-mcp
+         https://learn.microsoft.com/dotnet/ai/quickstarts/build-mcp-server -->
+    <PackageId>$(AssemblyName)</PackageId>
+    <PackAsTool>true</PackAsTool>
+    <PackageType>McpServer</PackageType>
+    <PublishSelfContained>true</PublishSelfContained>
+    <RuntimeIdentifiers>win-x64;win-arm64;linux-x64;linux-arm64;osx-x64;osx-arm64</RuntimeIdentifiers>
+    <ToolCommandName>$([System.String]::Copy('$(AssemblyName)').Replace('.', '-').Replace(' ', '-'))</ToolCommandName>
+    <McpServerManifestSource>$(MSBuildProjectDirectory)\.mcp\server.json</McpServerManifestSource>
+    <GeneratedMcpServerManifest>$(MSBuildProjectDirectory)\obj\mcp\$(TargetFramework)\$(RuntimeIdentifier)\server.json</GeneratedMcpServerManifest>
+    <McpServerManifestVersion Condition="'$(PackageVersion)' != ''">$(PackageVersion)</McpServerManifestVersion>
+    <McpServerManifestVersion Condition="'$(McpServerManifestVersion)' == ''">$(Version)</McpServerManifestVersion>
+<!--#endif-->
   </PropertyGroup>
 
-  <!-- 
-    For packaging as a dotnet global tool 
-    https://learn.microsoft.com/dotnet/core/tools/global-tools-how-to-create
-  -->
-  <!--
-  <PropertyGroup>
-    <PackageId>ConsoleApp</PackageId>
-    <PackAsTool>true</PackAsTool>
-    <ToolCommandName>ConsoleApp</ToolCommandName>
-  </PropertyGroup>
-  -->
+<!--#if (mcp)-->
+  <UsingTask
+    TaskName="SyncMcpServerManifestVersion"
+    TaskFactory="RoslynCodeTaskFactory"
+    AssemblyFile="$([MSBuild]::NormalizePath('$(MSBuildToolsPath)', 'Microsoft.Build.Tasks.Core.dll'))">
+    <ParameterGroup>
+      <SourceFile ParameterType="System.String" Required="true" />
+      <OutputFile ParameterType="System.String" Required="true" />
+      <Version ParameterType="System.String" Required="true" />
+    </ParameterGroup>
+    <Task>
+      <Using Namespace="System.IO" />
+      <Using Namespace="System.Text.RegularExpressions" />
+      <Code Type="Fragment" Language="cs"><![CDATA[
+        string content = File.ReadAllText(SourceFile);
+
+        Regex versionPattern = new Regex("(^\\s*\"version\"\\s*:\\s*\")[^\"]*(\"\\s*,?\\s*$)", RegexOptions.Multiline);
+        MatchCollection versionMatches = versionPattern.Matches(content);
+        if (versionMatches.Count < 2)
+        {
+            throw new InvalidDataException(string.Format("The MCP server manifest '{0}' does not contain the expected version entries.", SourceFile));
+        }
+
+        content = versionPattern.Replace(
+            content,
+            match => match.Groups[1].Value + Version + match.Groups[2].Value);
+
+        string outputDirectory = Path.GetDirectoryName(OutputFile);
+        if (string.IsNullOrEmpty(outputDirectory))
+        {
+            throw new InvalidDataException(string.Format("Could not determine the output directory for '{0}'.", OutputFile));
+        }
+
+        Directory.CreateDirectory(outputDirectory);
+        File.WriteAllText(OutputFile, content);
+      ]]></Code>
+    </Task>
+  </UsingTask>
+<!--#endif-->
 
   <ItemGroup>
+<!--#if (mcp)-->
+    <PackageReference Include="Microsoft.Extensions.Hosting" />
+    <PackageReference Include="ModelContextProtocol" />
+<!--#else-->
     <PackageReference Include="System.CommandLine" />
+<!--#endif-->
   </ItemGroup>
+
+<!--#if (mcp)-->
+  <ItemGroup>
+    <None Include="$(GeneratedMcpServerManifest)" Pack="true" PackagePath="/.mcp/" Visible="false" />
+  </ItemGroup>
+
+  <Target Name="GenerateMcpServerManifest" BeforeTargets="GenerateNuspec">
+    <SyncMcpServerManifestVersion
+      SourceFile="$(McpServerManifestSource)"
+      OutputFile="$(GeneratedMcpServerManifest)"
+      Version="$(McpServerManifestVersion)" />
+  </Target>
+<!--#endif-->
 
 </Project>

--- a/templates/Console/ConsoleApp/ConsoleApp/Program.cs
+++ b/templates/Console/ConsoleApp/ConsoleApp/Program.cs
@@ -1,4 +1,44 @@
-﻿using System.CommandLine;
+//#if (mcp)
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using ModelContextProtocol.Server;
+using System.ComponentModel;
+
+namespace ConsoleApp;
+
+public sealed class Program
+{
+    private static Task Main(string[] args)
+    {
+        // NuGet MCP packaging guidance:
+        // https://learn.microsoft.com/nuget/concepts/nuget-mcp
+        // MCP C# SDK docs:
+        // https://github.com/modelcontextprotocol/csharp-sdk
+        HostApplicationBuilder builder = Host.CreateApplicationBuilder(args);
+
+        builder.Services
+            .AddMcpServer()
+            .WithStdioServerTransport()
+            .WithToolsFromAssembly();
+
+        return builder.Build().RunAsync();
+    }
+}
+
+[McpServerToolType]
+public sealed class MathTools
+{
+    [McpServerTool, Description("Adds two numbers together.")]
+    public string Add(
+        [Description("The first number to add.")] int number1,
+        [Description("The second number to add.")] int number2)
+    {
+        int result = number1 + number2;
+        return $"The result is {result}";
+    }
+}
+//#else
+using System.CommandLine;
 
 namespace ConsoleApp;
 
@@ -25,6 +65,7 @@ public sealed class Program
             number1,
             number2
         };
+
         addCommand.SetAction((ParseResult parseResult) =>
         {
             int value1 = parseResult.CommandResult.GetValue(number1);
@@ -41,3 +82,4 @@ public sealed class Program
         return rootCommand;
     }
 }
+//#endif

--- a/templates/Console/ConsoleApp/Directory.Packages.props
+++ b/templates/Console/ConsoleApp/Directory.Packages.props
@@ -25,6 +25,10 @@
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.1" />
+<!--#if (mcp)-->
+    <!-- MCP C# SDK docs: https://github.com/modelcontextprotocol/csharp-sdk -->
+    <PackageVersion Include="ModelContextProtocol" Version="1.2.0" />
+<!--#endif-->
     <PackageVersion Include="System.CommandLine" Version="2.0.5" />
     <PackageVersion Include="TUnit" Version="1.22.6" />
     <PackageVersion Include="TUnit.Assertions" Version="1.22.6" />

--- a/templates/Console/ConsoleApp/LICENSE.md
+++ b/templates/Console/ConsoleApp/LICENSE.md
@@ -1,0 +1,22 @@
+
+The MIT License (MIT)
+
+Copyright (c) 2022 Kevin Bost
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/templates/Console/ConsoleApp/README.md
+++ b/templates/Console/ConsoleApp/README.md
@@ -1,73 +1,129 @@
 # Command line app template
-This template creates a [System.CommandLine](https://github.com/dotnet/command-line-api) solution, along with unit tests.
 
+This template creates a [System.CommandLine](https://github.com/dotnet/command-line-api) solution with unit tests and CI/CD scaffolding.
+
+When you pass `--mcp`, the template instead scaffolds a stdio [Model Context Protocol](https://modelcontextprotocol.io/introduction) server that is ready to pack and publish as a NuGet-hosted MCP tool.
 
 ## Template
-Create a new app in your current directory by running.
+
+Create a new app in your current directory by running:
 
 ```cli
-> dotnet new keboo.console
+dotnet new keboo.console
 ```
 
 ### Parameters
+
 [Default template options](https://learn.microsoft.com/dotnet/core/tools/dotnet-new#options)
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `--mcp` | Configure the app as a NuGet-hosted MCP server instead of a System.CommandLine CLI | `false` |
 | `--pipeline` | CI/CD provider to use. Options: `github`, `azuredevops`, `none` | `github` |
-| `--sln` | Use legacy .sln format instead of .slnx format | `false` |
+| `--sln` | Use legacy `.sln` format instead of `.slnx` format | `false` |
 | `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |
 
-**Example with Azure DevOps:**
+### Examples
+
+**Default CLI app**
+
 ```cli
-> dotnet new keboo.console --pipeline azuredevops
+dotnet new keboo.console
 ```
 
-**Example with no CI/CD pipeline:**
+**Azure DevOps pipeline**
+
 ```cli
-> dotnet new keboo.console --pipeline none
+dotnet new keboo.console --pipeline azuredevops
 ```
 
-**Example with legacy .sln format:**
+**No CI/CD pipeline**
+
 ```cli
-> dotnet new keboo.console --sln true
+dotnet new keboo.console --pipeline none
 ```
 
-**Example with MSTest:**
+**Legacy solution format**
+
 ```cli
-> dotnet new keboo.console --tests mstest
+dotnet new keboo.console --sln true
 ```
 
-**Example with no tests:**
+**MSTest**
+
 ```cli
-> dotnet new keboo.console --tests none
+dotnet new keboo.console --tests mstest
 ```
 
-## Updating .NET Version
+**No tests**
+
+```cli
+dotnet new keboo.console --tests none
+```
+
+**NuGet-hosted MCP server**
+
+```cli
+dotnet new keboo.console --mcp
+```
+
+**NuGet-hosted MCP server with xUnit**
+
+```cli
+dotnet new keboo.console --mcp --tests xunit
+```
+
+## MCP option
+
+When `--mcp` is enabled the template:
+
+1. Replaces the `System.CommandLine` sample with a stdio MCP server built on the [ModelContextProtocol C# SDK](https://github.com/modelcontextprotocol/csharp-sdk).
+2. Configures the project as a .NET tool package with `PackAsTool`, `PackageType` `McpServer`, self-contained publish defaults, and common runtime identifiers.
+3. Includes a `.mcp/server.json` file so NuGet.org and MCP clients can discover the package metadata.
+4. Regenerates the packaged `.mcp/server.json` during `dotnet pack` so its version entries stay aligned with the project/package version.
+
+Before publishing, review and customize:
+
+1. The package metadata generated from your project name, especially `PackageId` and the tool command name.
+2. The placeholder repository values in `.mcp/server.json`.
+3. The sample `MathTools` class and its tool descriptions, arguments, and any environment variables you want to expose.
+
+For background and publishing guidance, see:
+
+1. [MCP servers in NuGet packages](https://learn.microsoft.com/nuget/concepts/nuget-mcp)
+2. [Create a minimal MCP server using C# and publish to NuGet](https://learn.microsoft.com/dotnet/ai/quickstarts/build-mcp-server)
+3. [Generic `server.json` schema reference](https://github.com/modelcontextprotocol/registry/blob/main/docs/reference/server-json/generic-server-json.md)
+
+## Updating .NET version
 
 This template uses a `global.json` file to specify the required .NET SDK version. To update the .NET SDK version:
 
-1. Update the `global.json` file in the solution root
+1. Update the `global.json` file in the solution root.
 2. Update the `<TargetFramework>` in the `csproj` files.
 
-## Key Features
+## Key features
 
-### Build Customization
+### Build customization
+
 [Docs](https://learn.microsoft.com/visualstudio/msbuild/customize-by-directory?view=vs-2022&WT.mc_id=DT-MVP-5003472)
 
-### Centralized Package Management
+### Centralized package management
+
 [Docs](https://learn.microsoft.com/nuget/consume-packages/Central-Package-Management?WT.mc_id=DT-MVP-5003472)
 
 ### NuGet package source mapping
+
 [Docs](https://learn.microsoft.com/nuget/consume-packages/package-source-mapping?WT.mc_id=DT-MVP-5003472)
 
-### GitHub Actions / Azure DevOps Pipeline
-Build, test, and code coverage reporting included. Use `--pipeline` parameter to choose between GitHub Actions (default) or Azure DevOps Pipelines.
+### GitHub Actions / Azure DevOps pipeline
 
-### Solution File Format (slnx)
-By default, this template uses the new `.slnx` (XML-based solution) format introduced in .NET 9. This modern format is more maintainable and easier to version control compared to the legacy `.sln` format.
+Build, test, and code coverage reporting are included. Use `--pipeline` to choose between GitHub Actions (default), Azure DevOps Pipelines, or no CI/CD files.
 
-[Blog: Introducing slnx support in the dotnet CLI](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/?WT.mc_id=DT-MVP-5003472)  
-[Docs: dotnet sln command](https://learn.microsoft.com/dotnet/core/tools/dotnet-sln?WT.mc_id=DT-MVP-5003472)
+### Solution file format (`.slnx`)
 
-If you need to use the legacy `.sln` format, use the `--sln true` parameter when creating the template.
+By default, this template uses the new `.slnx` (XML-based solution) format introduced in .NET 9. This modern format is more maintainable and easier to version control than the legacy `.sln` format.
+
+1. [Blog: Introducing slnx support in the dotnet CLI](https://devblogs.microsoft.com/dotnet/introducing-slnx-support-dotnet-cli/?WT.mc_id=DT-MVP-5003472)
+2. [Docs: `dotnet sln` command](https://learn.microsoft.com/dotnet/core/tools/dotnet-sln?WT.mc_id=DT-MVP-5003472)
+
+If you need the legacy `.sln` format, use `--sln true` when creating the template.


### PR DESCRIPTION
## Why
The console template only scaffolded a System.CommandLine app, but it also needs to support creating a NuGet-hosted MCP tool. The generated MCP manifest also needed to stay in sync with the packaged version so published metadata does not drift.

## What changed
- Adds a `--mcp` template option to `keboo.console`.
- Switches the generated app to a stdio `ModelContextProtocol` server when `--mcp` is used, while preserving the existing CLI path by default.
- Configures the MCP variant as a NuGet tool package with `PackageType` `McpServer`, self-contained multi-RID packaging, and an embedded `.mcp/server.json`.
- Adds an MSBuild `RoslynCodeTaskFactory` target that regenerates the packaged MCP manifest before `GenerateNuspec`, keeping both manifest version fields aligned with the effective package version.
- Updates the console template docs and repo README, and adds the missing template `LICENSE.md` so generated projects can pack successfully.

## Notes
The manifest sync mirrors the regex-based approach from `Keboo/Keboo.Mcp#11`, but prefers `PackageVersion` when it is set and falls back to `Version` otherwise.

Validated by generating both the default console app and the `--mcp` variant, then packing the MCP app with `-p:Version=1.2.3` and confirming the packaged `.mcp/server.json` used `1.2.3` for both version entries.