### PR TITLE
Fix Aspire template MCP command syntax

### DIFF
--- a/templates/Aspire/ReactApp/.mcp.json
+++ b/templates/Aspire/ReactApp/.mcp.json
@@ -4,8 +4,8 @@
       "type": "stdio",
       "command": "aspire",
       "args": [
-        "mcp",
-        "start"
+        "agent",
+        "mcp"
       ]
     },
     "playwright": {

--- a/templates/Aspire/ReactApp/.vscode/mcp.json
+++ b/templates/Aspire/ReactApp/.vscode/mcp.json
@@ -4,8 +4,8 @@
       "type": "stdio",
       "command": "aspire",
       "args": [
-        "mcp",
-        "start"
+        "agent",
+        "mcp"
       ]
     },
     "playwright": {


### PR DESCRIPTION
## Why
Recent Aspire CLI versions moved MCP startup from `aspire mcp start` to `aspire agent mcp`. The Aspire React template still scaffolded the old command, so newly created projects could generate broken MCP configuration against current Aspire tooling.

## What changed
This updates the Aspire React template MCP configs to launch the current command in both generated entry points:

- `.mcp.json`
- `.vscode/mcp.json`

## Notes
No app code or package versions changed. This only updates the scaffolded Aspire CLI invocation so generated projects stay compatible with the current MCP command surface.