### PR TITLE
Improve Avalonia template metadata and creation flow

### DIFF
--- a/templates/Avalonia/AvaloniaSolution/.template.config/template.json
+++ b/templates/Avalonia/AvaloniaSolution/.template.config/template.json
@@ -7,6 +7,7 @@
   ],
   "identity": "Keboo.Avalonia.Solution",
   "name": "Keboo Avalonia Application",
+  "description": "Creates a cross-platform Avalonia solution with Desktop, Browser, Android, and iOS heads.",
   "shortName": "keboo.avalonia",
   "icon": "favicon.ico",
   "tags": {
@@ -15,6 +16,31 @@
   },
   "preferNameDirectory":true,
   "sourceName": "SampleAvaloniaApplication",
+  "primaryOutputs": [
+    {
+      "condition": "(sln && !no-sln)",
+      "path": "SampleAvaloniaApplication.sln"
+    },
+    {
+      "condition": "(!sln && !no-sln)",
+      "path": "SampleAvaloniaApplication.slnx"
+    },
+    {
+      "path": "SampleAvaloniaApplication.Desktop/SampleAvaloniaApplication.Desktop.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "description": "Review the generated README for the recommended restore command and workload guidance.",
+      "manualInstructions": [
+        {
+          "text": "Open README.md for the recommended Desktop restore command and for workload guidance for the optional Browser, Android, and iOS projects."
+        }
+      ],
+      "actionId": "AC1156F7-BB77-4DB8-B28F-24EEBCCA1E5C",
+      "continueOnError": true
+    }
+  ],
   "SpecialCustomOperations": {
     "**.slnx": {
       "operations": [
@@ -44,47 +70,8 @@
     "no-sln": {
       "type": "parameter",
       "dataType":"bool",
-      "defaultValue": "false"
-    },
-    "tests": {
-      "type": "parameter",
-      "dataType": "choice",
-      "choices": [
-        {
-          "choice": "xunit",
-          "description": "Use xUnit v3 testing framework"
-        },
-        {
-          "choice": "mstest",
-          "description": "Use MSTest testing framework"
-        },
-        {
-          "choice": "tunit",
-          "description": "Use TUnit testing framework"
-        },
-        {
-          "choice": "none",
-          "description": "Do not include tests"
-        }
-      ],
-      "defaultValue": "tunit",
-      "description": "The testing framework to use"
-    },
-    "useXunit": {
-      "type": "computed",
-      "value": "(tests == \"xunit\")"
-    },
-    "useMstest": {
-      "type": "computed",
-      "value": "(tests == \"mstest\")"
-    },
-    "useTunit": {
-      "type": "computed",
-      "value": "(tests == \"tunit\")"
-    },
-    "noTests": {
-      "type": "computed",
-      "value": "(tests == \"none\")"
+      "defaultValue": "false",
+      "description": "Do not include solution files in the generated output"
     },
     "sln": {
       "type": "parameter",
@@ -113,12 +100,6 @@
           "condition": "(!sln && !no-sln)",
           "exclude": [
             "SampleAvaloniaApplication.sln"
-          ]
-        },
-        {
-          "condition": "(noTests)",
-          "exclude": [
-            "SampleAvaloniaApplication.Tests/**"
           ]
         }
       ]

--- a/templates/Avalonia/AvaloniaSolution/README.md
+++ b/templates/Avalonia/AvaloniaSolution/README.md
@@ -14,23 +14,28 @@ Create a new app in your current directory by running.
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `--no-sln` | Do not include solution files in the generated output | `false` |
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
-| `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |
 
 **Example with legacy .sln format:**
 ```cli
 > dotnet new keboo.avalonia --sln true
 ```
 
-**Example with MSTest:**
+**Example without solution files:**
 ```cli
-> dotnet new keboo.avalonia --tests mstest
+> dotnet new keboo.avalonia --no-sln true
 ```
 
-**Example with no tests:**
+## After creation
+
+Restore the desktop head to pull in the shared app dependencies:
+
 ```cli
-> dotnet new keboo.avalonia --tests none
+> dotnet restore SampleAvaloniaApplication.Desktop/SampleAvaloniaApplication.Desktop.csproj
 ```
+
+The generated solution also includes optional Browser, Android, and iOS heads. Install the .NET workloads you need before restoring or building those projects.
 
 ## Updating .NET Version
 


### PR DESCRIPTION
## Summary
- add a top-level description, primary outputs, and template-local post-creation guidance for the Avalonia solution template
- remove the stale `--tests` option from the Avalonia template config and README because this template does not generate test projects
- document the recommended desktop restore flow and optional workload guidance in the generated README

## Validation
- `dotnet pack -o <isolated artifacts folder>`
- `dotnet new install <nupkg> --debug:custom-hive <isolated hive>`
- `dotnet new keboo.avalonia --help --debug:custom-hive <isolated hive>`
- `dotnet new keboo.avalonia -n AvaloniaFlowCheck -o <isolated output> --debug:custom-hive <isolated hive>`
- `dotnet new keboo.avalonia -n AvaloniaNoSln -o <isolated output> --no-sln true --debug:custom-hive <isolated hive>`