### PR TITLE
Improve WPF template metadata and constraints

### DIFF
--- a/templates/WPF/WpfApp/.template.config/template.json
+++ b/templates/WPF/WpfApp/.template.config/template.json
@@ -7,6 +7,7 @@
   ],
   "identity": "Keboo.WpfTemplates.FullApp",
   "name": "Keboo Full WPF Application",
+  "description": "Creates a Windows-only WPF MVVM solution with optional tests and CI pipeline selection.",
   "shortName": "keboo.wpf",
   "icon": "favicon.ico",
   "tags": {
@@ -15,6 +16,12 @@
   },
   "preferNameDirectory":true,
   "sourceName": "WpfApp",
+  "constraints": {
+    "windows-only": {
+      "type": "os",
+      "args": "Windows"
+    }
+  },
   "SpecialCustomOperations": {
     "**.slnx": {
       "operations": [
@@ -126,6 +133,15 @@
       "value": "(pipeline == \"none\")"
     }
   },
+  "primaryOutputs": [
+    {
+      "path": "WpfApp/WpfApp.csproj"
+    },
+    {
+      "condition": "(noTests == \"False\")",
+      "path": "WpfApp.Tests/WpfApp.Tests.csproj"
+    }
+  ],
   "sources": [
     {
       "modifiers": [
@@ -137,13 +153,13 @@
           ]
         },
         {
-          "condition": "(sln && !no-sln)",
+          "condition": "(sln == \"True\" && no-sln == \"False\")",
           "exclude": [
             "WpfApp.slnx"
           ]
         },
         {
-          "condition": "(!sln && !no-sln)",
+          "condition": "(sln == \"False\" && no-sln == \"False\")",
           "exclude": [
             "WpfApp.sln"
           ]
@@ -208,6 +224,73 @@
           ]
         }
       ]
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(sln == \"True\" && no-sln == \"False\")",
+      "description": "Restore NuGet packages required by this solution.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true,
+      "args": {
+        "files": [
+          "WpfApp.sln"
+        ]
+      }
+    },
+    {
+      "condition": "(sln == \"False\" && no-sln == \"False\")",
+      "description": "Restore NuGet packages required by this solution.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true,
+      "args": {
+        "files": [
+          "WpfApp.slnx"
+        ]
+      }
+    },
+    {
+      "condition": "(no-sln == \"True\" && noTests == \"False\")",
+      "description": "Restore NuGet packages required by these projects.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true,
+      "args": {
+        "files": [
+          "WpfApp/WpfApp.csproj",
+          "WpfApp.Tests/WpfApp.Tests.csproj"
+        ]
+      }
+    },
+    {
+      "condition": "(no-sln == \"True\" && noTests == \"True\")",
+      "description": "Restore NuGet packages required by this project.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore'"
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true,
+      "args": {
+        "files": [
+          "WpfApp/WpfApp.csproj"
+        ]
+      }
     }
   ]
 }

--- a/templates/WPF/WpfApp/README.md
+++ b/templates/WPF/WpfApp/README.md
@@ -1,5 +1,5 @@
 # WPF app template
-This template creates a full WPF application, along with unit tests.
+This template creates a full Windows-only WPF application, with optional unit tests.
 
 ## Template
 Create a new app in your current directory by running.
@@ -7,6 +7,8 @@ Create a new app in your current directory by running.
 ```cli
 > dotnet new keboo.wpf
 ```
+
+The template is only available on Windows hosts because WPF targets Windows.
 
 ### Parameters
 [Default template options](https://learn.microsoft.com/dotnet/core/tools/dotnet-new#options)


### PR DESCRIPTION
## Summary
- add a top-level description and Windows OS constraint to the WPF template
- add primary outputs and restore post-actions for solution and no-solution flows
- align the WPF template README with the Windows-only behavior

## Validation
- pack and install the template package with an isolated custom hive
- instantiate WPF template variants for `.slnx`, `.sln`, `--no-sln`, and `--no-sln --tests none`
- build the generated outputs successfully