### PR TITLE
Improve NuGet library template metadata and creation flow

### DIFF
--- a/templates/Library/NuGet/.template.config/template.json
+++ b/templates/Library/NuGet/.template.config/template.json
@@ -7,14 +7,59 @@
   ],
   "identity": "Keboo.Library.NuGet",
   "name": "Keboo Class Library for NuGet",
+  "description": "Creates a solution-scoped NuGet-ready class library with optional tests and CI/CD pipeline files.",
   "shortName": "keboo.nuget",
   "icon": "favicon.ico",
   "tags": {
     "language": "C#",
     "type": "solution"
   },
-  "preferNameDirectory":true,
+  "preferNameDirectory": true,
   "sourceName": "NuGetLib",
+  "primaryOutputs": [
+    {
+      "path": "NuGetLib/NuGetLib.csproj"
+    },
+    {
+      "condition": "(!noTests)",
+      "path": "NuGetLib.Tests/NuGetLib.Tests.csproj"
+    }
+  ],
+  "postActions": [
+    {
+      "condition": "(!skipRestore && noTests)",
+      "description": "Restore NuGet packages required by the generated projects.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore' for the generated solution or project files."
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true,
+      "args": {
+        "files": [
+          "NuGetLib/NuGetLib.csproj"
+        ]
+      }
+    },
+    {
+      "condition": "(!skipRestore && !noTests)",
+      "description": "Restore NuGet packages required by the generated projects.",
+      "manualInstructions": [
+        {
+          "text": "Run 'dotnet restore' for the generated solution or project files."
+        }
+      ],
+      "actionId": "210D431B-A78B-4D2F-B762-4ED3E3EA9025",
+      "continueOnError": true,
+      "args": {
+        "files": [
+          "NuGetLib/NuGetLib.csproj",
+          "NuGetLib.Tests/NuGetLib.Tests.csproj"
+        ]
+      }
+    }
+  ],
   "SpecialCustomOperations": {
     "**.slnx": {
       "operations": [
@@ -48,6 +93,12 @@
       "parameters": {
         "defaultFormat":"d"
       }
+    },
+    "skipRestore": {
+      "type": "parameter",
+      "dataType": "bool",
+      "defaultValue": "false",
+      "description": "If specified, skips the automatic restore of the generated projects on create."
     },
     "no-sln": {
       "type": "parameter",

--- a/templates/Library/NuGet/README.md
+++ b/templates/Library/NuGet/README.md
@@ -9,11 +9,15 @@ Create a new app in your current directory by running.
 > dotnet new keboo.nuget
 ```
 
+The generated projects are restored automatically after creation. Use `--skipRestore true` to skip that step.
+
 ### Parameters
 [Default template options](https://learn.microsoft.com/dotnet/core/tools/dotnet-new#options)
 
 | Parameter | Description | Default |
 |-----------|-------------|---------|
+| `--skipRestore` | Skip the automatic restore after template creation | `false` |
+| `--no-sln` | Do not include a solution file | `false` |
 | `--pipeline` | CI/CD provider to use. Options: `github`, `azuredevops`, `none` | `github` |
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
 | `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |


### PR DESCRIPTION
## Summary
- add NuGet template description, primary outputs, and restore post-actions for a smoother `dotnet new` flow
- add the template `skipRestore` parameter so restore can be intentionally skipped
- sync the NuGet template README with the actual generated flow and template parameters

## Scope
- only `templates\Library\NuGet` files were changed

## Validation
- packed the template package locally
- installed it with `dotnet new install`
- instantiated the NuGet template in default and skip-restore modes
- built the generated sample outputs