### PR TITLE
Add Aspire React Solution to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ dotnet new uninstall Keboo.Dotnet.Templates
 
 ## Included templates
 
+- [Aspire React Solution](./templates/Aspire/ReactApp/README.md)
 - [Avalonia Solution](./templates/Avalonia/AvaloniaSolution/README.md)
 - [WPF Solution](./templates/WPF/WpfApp/README.md)
 - [NuGet Package Solution](./templates/Library/NuGet/README.md)


### PR DESCRIPTION
The Aspire template (`templates/Aspire/ReactApp`) exists in the repo but was missing from the "Included templates" list in the README. This adds it alongside the other templates so users can discover it.

- Added `[Aspire React Solution](./templates/Aspire/ReactApp/README.md)` as the first entry in the list.