### PR TITLE
Replace fastify/github-action-merge-dependabot with gh pr merge

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -667,7 +667,8 @@ jobs:
         run: echo "All tests completed successfully"
 
   automerge:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
+    needs: all-tests
     runs-on: ubuntu-latest
 
     permissions:
@@ -675,9 +676,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.12.0
-        with:
-          use-github-auto-merge: true
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
   push_nugets:
     if: ${{ github.event_name != 'pull_request' }}

--- a/templates/Aspire/ReactApp/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/ReactApp/.github/workflows/build-and-deploy.yml
@@ -136,7 +136,7 @@ jobs:
           retention-days: 1
 
   automerge:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
     needs: [build]
     runs-on: ubuntu-latest
 
@@ -145,7 +145,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.12.0
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
   # Get infrastructure outputs from Terraform state
   get-infrastructure-outputs:

--- a/templates/Console/ConsoleApp/.github/workflows/build-and-deploy.yml
+++ b/templates/Console/ConsoleApp/.github/workflows/build-and-deploy.yml
@@ -67,7 +67,8 @@ jobs:
           path: ./NuGet
 
   automerge:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
+    needs: build
     runs-on: ubuntu-latest
 
     permissions:
@@ -75,9 +76,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.12.0
-        with:
-          use-github-auto-merge: true
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
   deploy-nuget:
     if: ${{ github.event_name != 'pull_request' }}

--- a/templates/Library/NuGet/.github/workflows/build-and-deploy.yml
+++ b/templates/Library/NuGet/.github/workflows/build-and-deploy.yml
@@ -68,7 +68,8 @@ jobs:
           path: ${{env.DOTNET_ROOT}}/NuGet
 
   automerge:
-    if: ${{ github.event_name == 'pull_request' }}
+    if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
+    needs: build
     runs-on: ubuntu-latest
 
     permissions:
@@ -76,7 +77,11 @@ jobs:
       contents: write
 
     steps:
-      - uses: fastify/github-action-merge-dependabot@v3.12.0
+      - name: Enable auto-merge for Dependabot PRs
+        run: gh pr merge --auto --squash "${{ github.event.pull_request.number }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
 
   deploy-nuget:
     if: ${{ github.event_name != 'pull_request' }}


### PR DESCRIPTION
Replace the third-party `fastify/github-action-merge-dependabot` action with native `gh pr merge --auto --squash`.

**Changes:**
- Narrow the `automerge` job condition to only run for `dependabot[bot]` actor
- Add `needs: all-tests` (repo workflow) / `needs: build` (templates) so auto-merge only triggers after tests pass
- Use `GH_REPO` env var so `gh` works without a checkout step
- Applied to both the repo workflow and all template workflows