### PR TITLE
Add pull-requests: write permission to coverage comment workflows

### DIFF
--- a/templates/Console/ConsoleApp/.github/workflows/pr-code-coverage-comment.yml
+++ b/templates/Console/ConsoleApp/.github/workflows/pr-code-coverage-comment.yml
@@ -10,6 +10,13 @@ defaults:
   run:
     shell: pwsh
 
+# This is required by marocchino/sticky-pull-request-comment
+# You must enable read/write permissions to allow workflows to create comments on the PR.
+# On your repo navigate to: Settings > Actions > General > Workflow permissions, and make sure to enable read and write permissions.
+# https://github.com/marocchino/sticky-pull-request-comment#error-resource-not-accessible-by-integration
+permissions:
+  pull-requests: write
+
 jobs:
   post-code-coverage:
     runs-on: ubuntu-latest

--- a/templates/Library/NuGet/.github/workflows/pr-code-coverage-comment.yml
+++ b/templates/Library/NuGet/.github/workflows/pr-code-coverage-comment.yml
@@ -10,6 +10,13 @@ defaults:
   run:
     shell: pwsh
 
+# This is required by marocchino/sticky-pull-request-comment
+# You must enable read/write permissions to allow workflows to create comments on the PR.
+# On your repo navigate to: Settings > Actions > General > Workflow permissions, and make sure to enable read and write permissions.
+# https://github.com/marocchino/sticky-pull-request-comment#error-resource-not-accessible-by-integration
+permissions:
+  pull-requests: write
+
 jobs:
   post-code-coverage:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The Console and Library template workflows using `marocchino/sticky-pull-request-comment` were missing the required `permissions: pull-requests: write` block, causing "Resource not accessible by integration" errors.

Added the same permissions block (with explanatory comments) already present in the WPF template to:
- `templates/Console/ConsoleApp/.github/workflows/pr-code-coverage-comment.yml`
- `templates/Library/NuGet/.github/workflows/pr-code-coverage-comment.yml`