### PR TITLE
feat: Update Avalonia template to v12 and remove Avalonia.Diagnostics

### DIFF
--- a/templates/Avalonia/AvaloniaSolution/Directory.Packages.props
+++ b/templates/Avalonia/AvaloniaSolution/Directory.Packages.props
@@ -13,7 +13,7 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
     <!-- https://learn.microsoft.com/nuget/consume-packages/Central-Package-Management?WT.mc_id=DT-MVP-5003472#transitive-pinning -->
     <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
-    <AvaloniaVersion>11.3.14</AvaloniaVersion>
+    <AvaloniaVersion>12.0.2</AvaloniaVersion>
   </PropertyGroup>
   <!--
   This defines the set of centrally managed packages.
@@ -24,12 +24,11 @@
     <PackageVersion Include="Avalonia.Android" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Browser" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Desktop" Version="$(AvaloniaVersion)" />
-    <PackageVersion Include="Avalonia.Diagnostics" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Fonts.Inter" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.iOS" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="$(AvaloniaVersion)" />
     <PackageVersion Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection" Version="10.0.7" />
     <PackageVersion Include="Xamarin.AndroidX.Core.SplashScreen" Version="1.2.0.2" />
   </ItemGroup>
 </Project>

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/SampleAvaloniaApplication.csproj
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication/SampleAvaloniaApplication.csproj
@@ -15,8 +15,5 @@
     <PackageReference Include="Avalonia.Fonts.Inter" />
     <PackageReference Include="CommunityToolkit.Mvvm" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" />
-
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Condition="'$(Configuration)' == 'Debug'" Include="Avalonia.Diagnostics" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary

Updates the Avalonia solution template to Avalonia 12 and removes the now-discontinued `Avalonia.Diagnostics` package.

## Changes

- **Bump `AvaloniaVersion`** from `11.3.14` → `12.0.2`
- **Remove `Avalonia.Diagnostics`** — this package has no v12 release. Per the [Avalonia docs](https://docs.avaloniaui.net/tools/developer-tools/installation), it is replaced by the new standalone Developer Tools which requires a paid license, so no replacement has been added to the template.
- **Bump `Microsoft.Extensions.DependencyInjection`** from `10.0.6` → `10.0.7`