### PR TITLE
Add default branch protection ruleset

### DIFF
--- a/default-branch-ruleset.json
+++ b/default-branch-ruleset.json
@@ -1,0 +1,38 @@
+{
+  "id": 14217812,
+  "name": "main",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "Keboo/Keboo.SpectralTabletop",
+  "enforcement": "disabled",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "build",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
This ruleset configures protections for the default branch, enforcing a linear commit history, preventing branch deletion, and requiring a passing 'build' status check. It is initially set to `disabled`.
