### PR TITLE
Only run template tests for changed templates on PRs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,33 @@ env:
   DOTNET_VERSION: 10.x
 
 jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      console: ${{ github.event_name != 'pull_request' || steps.filter.outputs.console == 'true' || steps.filter.outputs.shared == 'true' }}
+      wpf: ${{ github.event_name != 'pull_request' || steps.filter.outputs.wpf == 'true' || steps.filter.outputs.shared == 'true' }}
+      library: ${{ github.event_name != 'pull_request' || steps.filter.outputs.library == 'true' || steps.filter.outputs.shared == 'true' }}
+      avalonia: ${{ github.event_name != 'pull_request' || steps.filter.outputs.avalonia == 'true' || steps.filter.outputs.shared == 'true' }}
+    steps:
+      - name: Detect changed templates
+        uses: dorny/paths-filter@v3
+        id: filter
+        continue-on-error: true
+        with:
+          token: ${{ github.token }}
+          filters: |
+            shared:
+              - 'Templates.csproj'
+              - 'global.json'
+            console:
+              - 'templates/Console/**'
+            wpf:
+              - 'templates/WPF/**'
+            library:
+              - 'templates/Library/**'
+            avalonia:
+              - 'templates/Avalonia/**'
+
   build:
     runs-on: windows-latest
 
@@ -41,7 +68,8 @@ jobs:
 
   test-console:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, detect-changes]
+    if: needs.detect-changes.outputs.console == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -225,7 +253,8 @@ jobs:
 
   test-wpf:
     runs-on: windows-latest
-    needs: build
+    needs: [build, detect-changes]
+    if: needs.detect-changes.outputs.wpf == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -409,7 +438,8 @@ jobs:
 
   test-library:
     runs-on: ubuntu-latest
-    needs: build
+    needs: [build, detect-changes]
+    if: needs.detect-changes.outputs.library == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -597,7 +627,8 @@ jobs:
 
   test-avalonia:
     runs-on: windows-latest
-    needs: build
+    needs: [build, detect-changes]
+    if: needs.detect-changes.outputs.avalonia == 'true'
     strategy:
       fail-fast: true
       matrix:
@@ -662,9 +693,14 @@ jobs:
     name: All Tests Summary
     runs-on: ubuntu-latest
     needs: [test-console, test-wpf, test-library, test-avalonia]
+    if: always()
     steps:
-      - name: Summary
-        run: echo "All tests completed successfully"
+      - name: Check test results
+        run: |
+          if ("${{ contains(needs.*.result, 'failure') }}" -eq "true" -or "${{ contains(needs.*.result, 'cancelled') }}" -eq "true") {
+            throw "One or more tests failed or were cancelled"
+          }
+          Write-Host "All tests completed successfully"
 
   automerge:
     if: ${{ github.event_name == 'pull_request' && github.actor == 'dependabot[bot]' }}
@@ -686,7 +722,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     name: Push NuGets
     runs-on: ubuntu-latest
-    needs: [build, test-console, test-wpf, test-library, test-avalonia]
+    needs: [build, all-tests]
 
     permissions:
       id-token: write

--- a/default-branch-ruleset.json
+++ b/default-branch-ruleset.json
@@ -1,0 +1,38 @@
+{
+  "id": 14217812,
+  "name": "main",
+  "target": "branch",
+  "source_type": "Repository",
+  "source": "Keboo/Keboo.SpectralTabletop",
+  "enforcement": "disabled",
+  "conditions": {
+    "ref_name": {
+      "exclude": [],
+      "include": [
+        "~DEFAULT_BRANCH"
+      ]
+    }
+  },
+  "rules": [
+    {
+      "type": "deletion"
+    },
+    {
+      "type": "required_linear_history"
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": false,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          {
+            "context": "build",
+            "integration_id": 15368
+          }
+        ]
+      }
+    }
+  ],
+  "bypass_actors": []
+}


### PR DESCRIPTION
## Summary

- Adds a \detect-changes\ job using \dorny/paths-filter@v3\ to detect which template directories (\Console\, \WPF\, \Library\, \Avalonia\) were modified in a PR
- Each \	est-*\ job is now gated with an \if:\ condition so it only runs when its template (or a shared file like \Templates.csproj\ / \global.json\) was changed
- Push to \main\ and \workflow_dispatch\ runs always test all templates (unchanged behaviour)
- Updates the \ll-tests\ gate with \if: always()\ and an explicit failure check so it works correctly as a branch protection status check when some test jobs are skipped
- Simplifies \push_nugets\ to depend on \[build, all-tests]\ instead of all four individual test jobs