### PR TITLE
fix: preserve hyphens in path references for hyphenated project names

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -161,7 +161,7 @@ jobs:
           dotnet new install $(Get-ChildItem -Path "Keboo.Dotnet.Templates.*.nupkg").Name
           mkdir TestConsoleApp
           Push-Location TestConsoleApp
-          dotnet new keboo.console ${{ matrix.template-args }}
+          dotnet new keboo.console -n my-console-app ${{ matrix.template-args }}
           
       - name: Verify slnx file exists
         if: matrix.check-slnx == true
@@ -239,16 +239,16 @@ jobs:
       - name: Build Project Only
         if: matrix.check-tests == false && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestConsoleApp/TestConsoleApp
+          Push-Location TestConsoleApp/my-console-app
           dotnet build
       
       - name: Build and Test Project Only
         if: matrix.check-tests == true && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestConsoleApp/TestConsoleApp
+          Push-Location TestConsoleApp/my-console-app
           dotnet build
           Pop-Location
-          Push-Location TestConsoleApp/TestConsoleApp.Tests
+          Push-Location TestConsoleApp/my-console-app.Tests
           dotnet test
 
   test-wpf:
@@ -346,7 +346,7 @@ jobs:
           dotnet new install $(Get-ChildItem -Path "Keboo.Dotnet.Templates.*.nupkg").Name
           mkdir TestWpfApp
           Push-Location TestWpfApp
-          dotnet new keboo.wpf ${{ matrix.template-args }}
+          dotnet new keboo.wpf -n my-wpf-app ${{ matrix.template-args }}
           
       - name: Verify slnx file exists
         if: matrix.check-slnx == true
@@ -424,16 +424,16 @@ jobs:
       - name: Build Project Only
         if: matrix.check-tests == false && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestWpfApp/TestWpfApp
+          Push-Location TestWpfApp/my-wpf-app
           dotnet build
       
       - name: Build and Test Project Only
         if: matrix.check-tests == true && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestWpfApp/TestWpfApp
+          Push-Location TestWpfApp/my-wpf-app
           dotnet build
           Pop-Location
-          Push-Location TestWpfApp/TestWpfApp.Tests
+          Push-Location TestWpfApp/my-wpf-app.Tests
           dotnet test
 
   test-library:
@@ -531,7 +531,7 @@ jobs:
           dotnet new install $(Get-ChildItem -Path "Keboo.Dotnet.Templates.*.nupkg").Name
           mkdir TestLibrary
           Push-Location TestLibrary
-          dotnet new keboo.nuget ${{ matrix.template-args }}
+          dotnet new keboo.nuget -n my-lib ${{ matrix.template-args }}
           
       - name: Verify slnx file exists
         if: matrix.check-slnx == true
@@ -611,18 +611,18 @@ jobs:
       - name: Build Project Only
         if: matrix.check-tests == false && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestLibrary/TestLibrary
+          Push-Location TestLibrary/my-lib
           dotnet build
           dotnet pack --configuration Release -o ./NuGet
       
       - name: Build and Test Project Only
         if: matrix.check-tests == true && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestLibrary/TestLibrary
+          Push-Location TestLibrary/my-lib
           dotnet build
           dotnet pack --configuration Release -o ./NuGet
           Pop-Location
-          Push-Location TestLibrary/TestLibrary.Tests
+          Push-Location TestLibrary/my-lib.Tests
           dotnet test
 
   test-avalonia:
@@ -662,7 +662,7 @@ jobs:
           dotnet new install $(Get-ChildItem -Path "Keboo.Dotnet.Templates.*.nupkg").Name
           mkdir TestAvalonia
           Push-Location TestAvalonia
-          dotnet new keboo.avalonia ${{ matrix.template-args }}
+          dotnet new keboo.avalonia -n my-avalonia-app ${{ matrix.template-args }}
           
       - name: Verify slnx file exists
         if: matrix.check-slnx == true

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -166,89 +166,89 @@ jobs:
       - name: Verify slnx file exists
         if: matrix.check-slnx == true
         run: |
-          if (-not (Test-Path "TestConsoleApp/*.slnx")) {
+          if (-not (Test-Path "TestConsoleApp/my-console-app/*.slnx")) {
             throw "Expected .slnx file not found"
           }
           Write-Host "Contents of .slnx file:"
-          Get-Content TestConsoleApp/*.slnx
+          Get-Content TestConsoleApp/my-console-app/*.slnx
           
       - name: Verify sln file exists
         if: matrix.check-sln == true
         run: |
-          if (-not (Test-Path "TestConsoleApp/*.sln")) {
+          if (-not (Test-Path "TestConsoleApp/my-console-app/*.sln")) {
             throw "Expected .sln file not found"
           }
           Write-Host "Contents of .sln file:"
-          Get-Content TestConsoleApp/*.sln
+          Get-Content TestConsoleApp/my-console-app/*.sln
           
       - name: Verify tests folder exists
         if: matrix.check-tests == true
         run: |
-          if (-not (Test-Path "TestConsoleApp/*.Tests")) {
+          if (-not (Test-Path "TestConsoleApp/my-console-app/my-console-app.Tests")) {
             throw "Expected Tests folder not found"
           }
           
       - name: Verify tests folder does not exist
         if: matrix.check-tests == false
         run: |
-          if (Test-Path "TestConsoleApp/*.Tests") {
+          if (Test-Path "TestConsoleApp/my-console-app/my-console-app.Tests") {
             throw "Tests folder should not exist"
           }
           
       - name: Verify .github folder exists
         if: matrix.check-github == true
         run: |
-          if (-not (Test-Path "TestConsoleApp/.github")) {
+          if (-not (Test-Path "TestConsoleApp/my-console-app/.github")) {
             throw "Expected .github folder not found"
           }
           
       - name: Verify .github folder does not exist
         if: matrix.check-github == false
         run: |
-          if (Test-Path "TestConsoleApp/.github") {
+          if (Test-Path "TestConsoleApp/my-console-app/.github") {
             throw ".github folder should not exist"
           }
           
       - name: Verify .devops folder exists
         if: matrix.check-devops == true
         run: |
-          if (-not (Test-Path "TestConsoleApp/.devops")) {
+          if (-not (Test-Path "TestConsoleApp/my-console-app/.devops")) {
             throw "Expected .devops folder not found"
           }
           
       - name: Verify .devops folder does not exist
         if: matrix.check-devops == false
         run: |
-          if (Test-Path "TestConsoleApp/.devops") {
+          if (Test-Path "TestConsoleApp/my-console-app/.devops") {
             throw ".devops folder should not exist"
           }
           
       - name: Build and Test Solution
         if: matrix.check-tests == true && (matrix.check-sln == true || matrix.check-slnx == true)
         run: |
-          Push-Location TestConsoleApp
+          Push-Location TestConsoleApp/my-console-app
           dotnet build
           dotnet test --no-build
           
       - name: Build Solution
         if: matrix.check-tests == false && (matrix.check-sln == true || matrix.check-slnx == true)
         run: |
-          Push-Location TestConsoleApp
+          Push-Location TestConsoleApp/my-console-app
           dotnet build
       
       - name: Build Project Only
         if: matrix.check-tests == false && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestConsoleApp/my-console-app
+          Push-Location TestConsoleApp/my-console-app/my-console-app
           dotnet build
       
       - name: Build and Test Project Only
         if: matrix.check-tests == true && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestConsoleApp/my-console-app
+          Push-Location TestConsoleApp/my-console-app/my-console-app
           dotnet build
           Pop-Location
-          Push-Location TestConsoleApp/my-console-app.Tests
+          Push-Location TestConsoleApp/my-console-app/my-console-app.Tests
           dotnet test
 
   test-wpf:
@@ -351,89 +351,89 @@ jobs:
       - name: Verify slnx file exists
         if: matrix.check-slnx == true
         run: |
-          if (-not (Test-Path "TestWpfApp/*.slnx")) {
+          if (-not (Test-Path "TestWpfApp/my-wpf-app/*.slnx")) {
             throw "Expected .slnx file not found"
           }
           Write-Host "Contents of .slnx file:"
-          Get-Content TestWpfApp/*.slnx
+          Get-Content TestWpfApp/my-wpf-app/*.slnx
           
       - name: Verify sln file exists
         if: matrix.check-sln == true
         run: |
-          if (-not (Test-Path "TestWpfApp/*.sln")) {
+          if (-not (Test-Path "TestWpfApp/my-wpf-app/*.sln")) {
             throw "Expected .sln file not found"
           }
           Write-Host "Contents of .sln file:"
-          Get-Content TestWpfApp/*.sln
+          Get-Content TestWpfApp/my-wpf-app/*.sln
           
       - name: Verify tests folder exists
         if: matrix.check-tests == true
         run: |
-          if (-not (Test-Path "TestWpfApp/*.Tests")) {
+          if (-not (Test-Path "TestWpfApp/my-wpf-app/my-wpf-app.Tests")) {
             throw "Expected Tests folder not found"
           }
           
       - name: Verify tests folder does not exist
         if: matrix.check-tests == false
         run: |
-          if (Test-Path "TestWpfApp/*.Tests") {
+          if (Test-Path "TestWpfApp/my-wpf-app/my-wpf-app.Tests") {
             throw "Tests folder should not exist"
           }
           
       - name: Verify .github folder exists
         if: matrix.check-github == true
         run: |
-          if (-not (Test-Path "TestWpfApp/.github")) {
+          if (-not (Test-Path "TestWpfApp/my-wpf-app/.github")) {
             throw "Expected .github folder not found"
           }
           
       - name: Verify .github folder does not exist
         if: matrix.check-github == false
         run: |
-          if (Test-Path "TestWpfApp/.github") {
+          if (Test-Path "TestWpfApp/my-wpf-app/.github") {
             throw ".github folder should not exist"
           }
           
       - name: Verify .devops folder exists
         if: matrix.check-devops == true
         run: |
-          if (-not (Test-Path "TestWpfApp/.devops")) {
+          if (-not (Test-Path "TestWpfApp/my-wpf-app/.devops")) {
             throw "Expected .devops folder not found"
           }
           
       - name: Verify .devops folder does not exist
         if: matrix.check-devops == false
         run: |
-          if (Test-Path "TestWpfApp/.devops") {
+          if (Test-Path "TestWpfApp/my-wpf-app/.devops") {
             throw ".devops folder should not exist"
           }
           
       - name: Build and Test Solution
         if: matrix.check-tests == true && (matrix.check-sln == true || matrix.check-slnx == true)
         run: |
-          Push-Location TestWpfApp
+          Push-Location TestWpfApp/my-wpf-app
           dotnet build
           dotnet test --no-build
           
       - name: Build Solution
         if: matrix.check-tests == false && (matrix.check-sln == true || matrix.check-slnx == true)
         run: |
-          Push-Location TestWpfApp
+          Push-Location TestWpfApp/my-wpf-app
           dotnet build
       
       - name: Build Project Only
         if: matrix.check-tests == false && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestWpfApp/my-wpf-app
+          Push-Location TestWpfApp/my-wpf-app/my-wpf-app
           dotnet build
       
       - name: Build and Test Project Only
         if: matrix.check-tests == true && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestWpfApp/my-wpf-app
+          Push-Location TestWpfApp/my-wpf-app/my-wpf-app
           dotnet build
           Pop-Location
-          Push-Location TestWpfApp/my-wpf-app.Tests
+          Push-Location TestWpfApp/my-wpf-app/my-wpf-app.Tests
           dotnet test
 
   test-library:
@@ -536,67 +536,67 @@ jobs:
       - name: Verify slnx file exists
         if: matrix.check-slnx == true
         run: |
-          if (-not (Test-Path "TestLibrary/*.slnx")) {
+          if (-not (Test-Path "TestLibrary/my-lib/*.slnx")) {
             throw "Expected .slnx file not found"
           }
           Write-Host "Contents of .slnx file:"
-          Get-Content TestLibrary/*.slnx
+          Get-Content TestLibrary/my-lib/*.slnx
           
       - name: Verify sln file exists
         if: matrix.check-sln == true
         run: |
-          if (-not (Test-Path "TestLibrary/*.sln")) {
+          if (-not (Test-Path "TestLibrary/my-lib/*.sln")) {
             throw "Expected .sln file not found"
           }
           Write-Host "Contents of .sln file:"
-          Get-Content TestLibrary/*.sln
+          Get-Content TestLibrary/my-lib/*.sln
           
       - name: Verify tests folder exists
         if: matrix.check-tests == true
         run: |
-          if (-not (Test-Path "TestLibrary/*.Tests")) {
+          if (-not (Test-Path "TestLibrary/my-lib/my-lib.Tests")) {
             throw "Expected Tests folder not found"
           }
           
       - name: Verify tests folder does not exist
         if: matrix.check-tests == false
         run: |
-          if (Test-Path "TestLibrary/*.Tests") {
+          if (Test-Path "TestLibrary/my-lib/my-lib.Tests") {
             throw "Tests folder should not exist"
           }
           
       - name: Verify .github folder exists
         if: matrix.check-github == true
         run: |
-          if (-not (Test-Path "TestLibrary/.github")) {
+          if (-not (Test-Path "TestLibrary/my-lib/.github")) {
             throw "Expected .github folder not found"
           }
           
       - name: Verify .github folder does not exist
         if: matrix.check-github == false
         run: |
-          if (Test-Path "TestLibrary/.github") {
+          if (Test-Path "TestLibrary/my-lib/.github") {
             throw ".github folder should not exist"
           }
           
       - name: Verify .devops folder exists
         if: matrix.check-devops == true
         run: |
-          if (-not (Test-Path "TestLibrary/.devops")) {
+          if (-not (Test-Path "TestLibrary/my-lib/.devops")) {
             throw "Expected .devops folder not found"
           }
           
       - name: Verify .devops folder does not exist
         if: matrix.check-devops == false
         run: |
-          if (Test-Path "TestLibrary/.devops") {
+          if (Test-Path "TestLibrary/my-lib/.devops") {
             throw ".devops folder should not exist"
           }
           
       - name: Build and Test Solution
         if: matrix.check-tests == true && (matrix.check-sln == true || matrix.check-slnx == true)
         run: |
-          Push-Location TestLibrary
+          Push-Location TestLibrary/my-lib/my-lib
           dotnet build
           dotnet test --no-build
           dotnet pack --configuration Release -o ./NuGet
@@ -604,25 +604,25 @@ jobs:
       - name: Build Solution
         if: matrix.check-tests == false && (matrix.check-sln == true || matrix.check-slnx == true)
         run: |
-          Push-Location TestLibrary
+          Push-Location TestLibrary/my-lib
           dotnet build
           dotnet pack --configuration Release -o ./NuGet
 
       - name: Build Project Only
         if: matrix.check-tests == false && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestLibrary/my-lib
+          Push-Location TestLibrary/my-lib/my-lib
           dotnet build
           dotnet pack --configuration Release -o ./NuGet
       
       - name: Build and Test Project Only
         if: matrix.check-tests == true && matrix.check-sln == false && matrix.check-slnx == false
         run: |
-          Push-Location TestLibrary/my-lib
+          Push-Location TestLibrary/my-lib/my-lib
           dotnet build
           dotnet pack --configuration Release -o ./NuGet
           Pop-Location
-          Push-Location TestLibrary/my-lib.Tests
+          Push-Location TestLibrary/my-lib/my-lib.Tests
           dotnet test
 
   test-avalonia:
@@ -667,25 +667,25 @@ jobs:
       - name: Verify slnx file exists
         if: matrix.check-slnx == true
         run: |
-          if (-not (Test-Path "TestAvalonia/*.slnx")) {
+          if (-not (Test-Path "TestAvalonia/my-avalonia-app/*.slnx")) {
             throw "Expected .slnx file not found"
           }
           Write-Host "Contents of .slnx file:"
-          Get-Content TestAvalonia/*.slnx
+          Get-Content TestAvalonia/my-avalonia-app/*.slnx
           
       - name: Verify sln file exists
         if: matrix.check-sln == true
         run: |
-          if (-not (Test-Path "TestAvalonia/*.sln")) {
+          if (-not (Test-Path "TestAvalonia/my-avalonia-app/*.sln")) {
             throw "Expected .sln file not found"
           }
           Write-Host "Contents of .sln file:"
-          Get-Content TestAvalonia/*.sln
+          Get-Content TestAvalonia/my-avalonia-app/*.sln
           
       - name: Build
         if: matrix.check-sln == true || matrix.check-slnx == true
         run: |
-          Push-Location TestAvalonia
+          Push-Location TestAvalonia/my-avalonia-app
           dotnet workload restore
           dotnet build
 

--- a/templates/Aspire/ReactApp/.aspire/settings.json
+++ b/templates/Aspire/ReactApp/.aspire/settings.json
@@ -1,3 +1,3 @@
 {
-  "appHostPath": "../ReactApp.AppHost/ReactApp.AppHost.csproj"
+  "appHostPath": "../__PROJECT_NAME__.AppHost/__PROJECT_NAME__.AppHost.csproj"
 }

--- a/templates/Aspire/ReactApp/.github/dependabot.yml
+++ b/templates/Aspire/ReactApp/.github/dependabot.yml
@@ -24,7 +24,7 @@ updates:
           - "*"
 
   - package-ecosystem: "npm" # Dependabot uses npm ecosystem for pnpm projects
-    directory: "/ReactApp.Web"
+    directory: "/__PROJECT_NAME__.Web"
     schedule:
       interval: "weekly"
     groups:

--- a/templates/Aspire/ReactApp/.github/workflows/build-and-deploy.yml
+++ b/templates/Aspire/ReactApp/.github/workflows/build-and-deploy.yml
@@ -23,7 +23,7 @@ defaults:
 env:
   DOTNET_VERSION: '10.0.x'
   NODE_VERSION: '20.x'
-  FRONTEND_PROJECT_PATH: 'ReactApp.Web'
+  FRONTEND_PROJECT_PATH: '__PROJECT_NAME__.Web'
   TERRAFORM_VERSION: '1.15.4'
 
 jobs:
@@ -78,11 +78,11 @@ jobs:
         run: |
           dotnet ef migrations has-pending-model-changes `
             --configuration Release `
-            --project ReactApp.Data/ReactApp.Data.csproj `
-           --startup-project ReactApp.AppHost/ReactApp.AppHost.csproj
+            --project __PROJECT_NAME__.Data/__PROJECT_NAME__.Data.csproj `
+           --startup-project __PROJECT_NAME__.AppHost/__PROJECT_NAME__.AppHost.csproj
 
       - name: Install Playwright browsers
-        run: pwsh ReactApp.UITests/bin/Release/net10.0/playwright.ps1 install --with-deps
+        run: pwsh __PROJECT_NAME__.UITests/bin/Release/net10.0/playwright.ps1 install --with-deps
 
       # Microsoft Testing Platform can stop the run once 10 tests fail in CI:
       # https://learn.microsoft.com/dotnet/core/testing/microsoft-testing-platform-cli-options
@@ -120,8 +120,8 @@ jobs:
             --self-contained `
             --no-build `
             --configuration Release `
-            --project ReactApp.Data/ReactApp.Data.csproj `
-            --startup-project .\ReactApp.AppHost\ReactApp.AppHost.csproj `
+            --project __PROJECT_NAME__.Data/__PROJECT_NAME__.Data.csproj `
+            --startup-project .\__PROJECT_NAME__.AppHost\__PROJECT_NAME__.AppHost.csproj `
             --output efbundle
 
       - name: Upload DB Migration

--- a/templates/Aspire/ReactApp/.template.config/template.json
+++ b/templates/Aspire/ReactApp/.template.config/template.json
@@ -59,7 +59,14 @@
       }
     }
   ],
-  "symbols": {},
+  "symbols": {
+    "projectName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "identity",
+      "replaces": "__PROJECT_NAME__"
+    }
+  },
   "sources": [
     {
       "modifiers": []

--- a/templates/Aspire/ReactApp/ReactApp.AppHost/AppHost.cs
+++ b/templates/Aspire/ReactApp/ReactApp.AppHost/AppHost.cs
@@ -49,7 +49,7 @@ var backend = builder.AddProject<Projects.ReactApp>("ReactApp-backend")
     .WithExternalHttpEndpoints()
     .PublishAsAzureContainerApp((infra, app) => app.Template.Scale.MaxReplicas = 1);
 
-var frontendApp = builder.AddJavaScriptApp(Resources.Frontend, "../ReactApp.Web", "dev")
+var frontendApp = builder.AddJavaScriptApp(Resources.Frontend, "../__PROJECT_NAME__.Web", "dev")
     .WithNpm(install: true)
     .WithHttpEndpoint(env: "PORT")
     .WithExternalHttpEndpoints()

--- a/templates/Aspire/ReactApp/ReactApp.AppHost/ReactApp.AppHost.csproj
+++ b/templates/Aspire/ReactApp/ReactApp.AppHost/ReactApp.AppHost.csproj
@@ -18,9 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReactApp.Core\ReactApp.Core.csproj" IsAspireProjectResource="false" />
-    <ProjectReference Include="..\ReactApp.Data\ReactApp.Data.csproj" IsAspireProjectResource="false" />
-    <ProjectReference Include="..\ReactApp\ReactApp.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.Core\__PROJECT_NAME__.Core.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\__PROJECT_NAME__.Data\__PROJECT_NAME__.Data.csproj" IsAspireProjectResource="false" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 
 </Project>

--- a/templates/Aspire/ReactApp/ReactApp.AppHost/Resources.cs
+++ b/templates/Aspire/ReactApp/ReactApp.AppHost/Resources.cs
@@ -260,7 +260,7 @@ public static class Resources
                         "run",
                         "--no-build",
                         "--project",
-                        "ReactApp.UITests\\ReactApp.UITests.csproj"
+                        "__PROJECT_NAME__.UITests\\__PROJECT_NAME__.UITests.csproj"
                     },
                     WorkingDirectory = GetSolutionDirectory()?.FullName,
                     EnvironmentVariables =
@@ -322,9 +322,9 @@ public static class Resources
                         "ef",
                         "migrations",
                         "--startup-project",
-                        "./ReactApp.AppHost",
+                        "./__PROJECT_NAME__.AppHost",
                         "--project",
-                        "./ReactApp.Data",
+                        "./__PROJECT_NAME__.Data",
                         "--no-build",
                         "add",
                         migrationNameResult.Data.Value
@@ -371,9 +371,9 @@ public static class Resources
                         "ef",
                         "migrations",
                         "--startup-project",
-                        "./ReactApp.AppHost",
+                        "./__PROJECT_NAME__.AppHost",
                         "--project",
-                        "./ReactApp.Data",
+                        "./__PROJECT_NAME__.Data",
                         "--no-build",
                         "remove"
                     },
@@ -463,9 +463,9 @@ public static class Resources
                     "--configuration",
                     configuration,
                     "--startup-project",
-                    "./ReactApp.AppHost",
+                    "./__PROJECT_NAME__.AppHost",
                     "--project",
-                    "./ReactApp.Data",
+                    "./__PROJECT_NAME__.Data",
                 },
                 WorkingDirectory = GetSolutionDirectory()?.FullName,
                 EnvironmentVariables =

--- a/templates/Aspire/ReactApp/ReactApp.Core.Tests/ReactApp.Core.Tests.csproj
+++ b/templates/Aspire/ReactApp/ReactApp.Core.Tests/ReactApp.Core.Tests.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReactApp.Core\ReactApp.Core.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.Core\__PROJECT_NAME__.Core.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Aspire/ReactApp/ReactApp.Core/ReactApp.Core.csproj
+++ b/templates/Aspire/ReactApp/ReactApp.Core/ReactApp.Core.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReactApp.Data\ReactApp.Data.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.Data\__PROJECT_NAME__.Data.csproj" />
   </ItemGroup>
 
 </Project>

--- a/templates/Aspire/ReactApp/ReactApp.UITests/README.md
+++ b/templates/Aspire/ReactApp/ReactApp.UITests/README.md
@@ -133,7 +133,7 @@ playwright install
 
 **Method 1: Standard (try this first)**
 ```bash
-cd ReactApp.UITests
+cd __PROJECT_NAME__.UITests
 dotnet test
 ```
 
@@ -141,14 +141,14 @@ dotnet test
 
 Terminal 1 - Start the AppHost:
 ```bash
-dotnet run --project ReactApp.AppHost
+dotnet run --project __PROJECT_NAME__.AppHost
 ```
 
 Terminal 2 - Run tests:
 ```bash
 # Get the frontend port from the Aspire dashboard
 export FRONTEND_URL=http://localhost:<port>
-cd ReactApp.UITests
+cd __PROJECT_NAME__.UITests
 dotnet test
 ```
 
@@ -252,12 +252,12 @@ Playwright automatically captures screenshots on test failures. Check the test r
 
 ```yaml
 - name: Install Playwright Browsers
-  run: pwsh ReactApp.UITests/bin/Debug/net10.0/playwright.ps1 install --with-deps
+  run: pwsh __PROJECT_NAME__.UITests/bin/Debug/net10.0/playwright.ps1 install --with-deps
 
 - name: Run UI Tests
   env:
     TEST_BASE_URL: https://staging.example.com
-  run: dotnet test ReactApp.UITests/ReactApp.UITests.csproj
+  run: dotnet test __PROJECT_NAME__.UITests/__PROJECT_NAME__.UITests.csproj
 ```
 
 ### Azure DevOps Example
@@ -268,13 +268,13 @@ Playwright automatically captures screenshots on test failures. Check the test r
   inputs:
     targetType: 'inline'
     script: |
-      pwsh ReactApp.UITests/bin/Debug/net10.0/playwright.ps1 install --with-deps
+      pwsh __PROJECT_NAME__.UITests/bin/Debug/net10.0/playwright.ps1 install --with-deps
 
 - task: DotNetCoreCLI@2
   displayName: 'Run UI Tests'
   inputs:
     command: 'test'
-    projects: 'ReactApp.UITests/ReactApp.UITests.csproj'
+    projects: '__PROJECT_NAME__.UITests/__PROJECT_NAME__.UITests.csproj'
   env:
     TEST_BASE_URL: $(TestBaseUrl)
 ```

--- a/templates/Aspire/ReactApp/ReactApp.UITests/ReactApp.UITests.csproj
+++ b/templates/Aspire/ReactApp/ReactApp.UITests/ReactApp.UITests.csproj
@@ -17,7 +17,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReactApp.AppHost\ReactApp.AppHost.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.AppHost\__PROJECT_NAME__.AppHost.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/templates/Aspire/ReactApp/ReactApp.slnx
+++ b/templates/Aspire/ReactApp/ReactApp.slnx
@@ -20,12 +20,12 @@
     <File Path=".github/workflows/build-and-deploy.yml" />
     <File Path=".github/workflows/deploy-infrastructure.yml" />
   </Folder>
-  <Project Path="ReactApp.AppHost/ReactApp.AppHost.csproj" />
-  <Project Path="ReactApp.Core.Tests/ReactApp.Core.Tests.csproj" />
-  <Project Path="ReactApp.Core/ReactApp.Core.csproj" />
-  <Project Path="ReactApp.Data/ReactApp.Data.csproj" />
-  <Project Path="ReactApp.ServiceDefaults/ReactApp.ServiceDefaults.csproj" />
-  <Project Path="ReactApp.UITests/ReactApp.UITests.csproj" Id="a75465c6-4ed1-4ab4-b492-9697c5727ffc" />
-  <Project Path="ReactApp.Web/ReactApp.Web.csproj" />
-  <Project Path="ReactApp/ReactApp.csproj" />
+  <Project Path="__PROJECT_NAME__.AppHost/__PROJECT_NAME__.AppHost.csproj" />
+  <Project Path="__PROJECT_NAME__.Core.Tests/__PROJECT_NAME__.Core.Tests.csproj" />
+  <Project Path="__PROJECT_NAME__.Core/__PROJECT_NAME__.Core.csproj" />
+  <Project Path="__PROJECT_NAME__.Data/__PROJECT_NAME__.Data.csproj" />
+  <Project Path="__PROJECT_NAME__.ServiceDefaults/__PROJECT_NAME__.ServiceDefaults.csproj" />
+  <Project Path="__PROJECT_NAME__.UITests/__PROJECT_NAME__.UITests.csproj" Id="a75465c6-4ed1-4ab4-b492-9697c5727ffc" />
+  <Project Path="__PROJECT_NAME__.Web/__PROJECT_NAME__.Web.csproj" />
+  <Project Path="__PROJECT_NAME__/__PROJECT_NAME__.csproj" />
 </Solution>

--- a/templates/Aspire/ReactApp/ReactApp/ReactApp.csproj
+++ b/templates/Aspire/ReactApp/ReactApp/ReactApp.csproj
@@ -2,17 +2,17 @@
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
-    <SpaRoot>..\ReactApp.Web\</SpaRoot>
+    <SpaRoot>..\__PROJECT_NAME__.Web\</SpaRoot>
     <SpaProxyServerUrl>http://localhost:5173</SpaProxyServerUrl>
     <SpaProxyLaunchCommand>pnpm dev</SpaProxyLaunchCommand>
     <EnableDefaultRazorComponentItems>false</EnableDefaultRazorComponentItems>
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReactApp.Core\ReactApp.Core.csproj" />
-    <ProjectReference Include="..\ReactApp.Data\ReactApp.Data.csproj" />
-    <ProjectReference Include="..\ReactApp.ServiceDefaults\ReactApp.ServiceDefaults.csproj" />
-    <ProjectReference Include="..\ReactApp.Web\ReactApp.Web.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.Core\__PROJECT_NAME__.Core.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.Data\__PROJECT_NAME__.Data.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.ServiceDefaults\__PROJECT_NAME__.ServiceDefaults.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__.Web\__PROJECT_NAME__.Web.csproj" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />
     <PackageReference Include="Microsoft.AspNetCore.SpaProxy" />

--- a/templates/Avalonia/AvaloniaSolution/.template.config/template.json
+++ b/templates/Avalonia/AvaloniaSolution/.template.config/template.json
@@ -59,6 +59,12 @@
     }
   },
   "symbols":{
+    "projectName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "identity",
+      "replaces": "__PROJECT_NAME__"
+    },
     "user_secrets_id":{
       "type": "generated",
       "generator": "guid",

--- a/templates/Avalonia/AvaloniaSolution/README.md
+++ b/templates/Avalonia/AvaloniaSolution/README.md
@@ -32,7 +32,7 @@ Create a new app in your current directory by running.
 Restore the desktop head to pull in the shared app dependencies:
 
 ```cli
-> dotnet restore SampleAvaloniaApplication.Desktop/SampleAvaloniaApplication.Desktop.csproj
+> dotnet restore __PROJECT_NAME__.Desktop/__PROJECT_NAME__.Desktop.csproj
 ```
 
 The generated solution also includes optional Browser, Android, and iOS heads. Install the .NET workloads you need before restoring or building those projects.

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Android/SampleAvaloniaApplication.Android.csproj
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Android/SampleAvaloniaApplication.Android.csproj
@@ -8,6 +8,7 @@
     <ApplicationDisplayVersion>1.0</ApplicationDisplayVersion>
     <AndroidPackageFormat>apk</AndroidPackageFormat>
     <AndroidEnableProfiledAot>False</AndroidEnableProfiledAot>
+    <RootNamespace>$(AssemblyName.Replace("-","_"))</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Android/SampleAvaloniaApplication.Android.csproj
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Android/SampleAvaloniaApplication.Android.csproj
@@ -22,6 +22,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SampleAvaloniaApplication\SampleAvaloniaApplication.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 </Project>

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Browser/SampleAvaloniaApplication.Browser.csproj
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Browser/SampleAvaloniaApplication.Browser.csproj
@@ -17,6 +17,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SampleAvaloniaApplication\SampleAvaloniaApplication.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 </Project>

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Desktop/SampleAvaloniaApplication.Desktop.csproj
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.Desktop/SampleAvaloniaApplication.Desktop.csproj
@@ -15,6 +15,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SampleAvaloniaApplication\SampleAvaloniaApplication.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 </Project>

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.iOS/SampleAvaloniaApplication.iOS.csproj
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.iOS/SampleAvaloniaApplication.iOS.csproj
@@ -16,6 +16,6 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\SampleAvaloniaApplication\SampleAvaloniaApplication.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 </Project>

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.sln
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.sln
@@ -3,15 +3,15 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.10.34707.107
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication", "SampleAvaloniaApplication\SampleAvaloniaApplication.csproj", "{468FB281-79A9-4C1F-9EA7-080DF4E4ECAF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication", "__PROJECT_NAME__\__PROJECT_NAME__.csproj", "{468FB281-79A9-4C1F-9EA7-080DF4E4ECAF}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.Android", "SampleAvaloniaApplication.Android\SampleAvaloniaApplication.Android.csproj", "{1B4914BF-CE72-4BA5-B7B4-C41C09E74F51}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.Android", "__PROJECT_NAME__.Android\__PROJECT_NAME__.Android.csproj", "{1B4914BF-CE72-4BA5-B7B4-C41C09E74F51}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.Desktop", "SampleAvaloniaApplication.Desktop\SampleAvaloniaApplication.Desktop.csproj", "{E44C3839-DDFE-4DA3-BC06-796CEC9AC8B9}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.Desktop", "__PROJECT_NAME__.Desktop\__PROJECT_NAME__.Desktop.csproj", "{E44C3839-DDFE-4DA3-BC06-796CEC9AC8B9}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.iOS", "SampleAvaloniaApplication.iOS\SampleAvaloniaApplication.iOS.csproj", "{F9460ABD-ED52-4001-A2F1-03FFCF915C47}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.iOS", "__PROJECT_NAME__.iOS\__PROJECT_NAME__.iOS.csproj", "{F9460ABD-ED52-4001-A2F1-03FFCF915C47}"
 EndProject
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.Browser", "SampleAvaloniaApplication.Browser\SampleAvaloniaApplication.Browser.csproj", "{76A3BFA3-4B1E-46B5-8BAA-BA558B258EAD}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "SampleAvaloniaApplication.Browser", "__PROJECT_NAME__.Browser\__PROJECT_NAME__.Browser.csproj", "{76A3BFA3-4B1E-46B5-8BAA-BA558B258EAD}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{2805EDF0-22F4-4F54-BE47-1212AB3BC273}"
 	ProjectSection(SolutionItems) = preProject

--- a/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.slnx
+++ b/templates/Avalonia/AvaloniaSolution/SampleAvaloniaApplication.slnx
@@ -9,11 +9,11 @@
     <File Path="NuGet.config" />
     <File Path="Settings.XamlStyler" />
   </Folder>
-  <Project Path="SampleAvaloniaApplication.Android/SampleAvaloniaApplication.Android.csproj">
+  <Project Path="__PROJECT_NAME__.Android/__PROJECT_NAME__.Android.csproj">
     <Deploy />
   </Project>
-  <Project Path="SampleAvaloniaApplication.Browser/SampleAvaloniaApplication.Browser.csproj" />
-  <Project Path="SampleAvaloniaApplication.Desktop/SampleAvaloniaApplication.Desktop.csproj" />
-  <Project Path="SampleAvaloniaApplication.iOS/SampleAvaloniaApplication.iOS.csproj" />
-  <Project Path="SampleAvaloniaApplication/SampleAvaloniaApplication.csproj" />
+  <Project Path="__PROJECT_NAME__.Browser/__PROJECT_NAME__.Browser.csproj" />
+  <Project Path="__PROJECT_NAME__.Desktop/__PROJECT_NAME__.Desktop.csproj" />
+  <Project Path="__PROJECT_NAME__.iOS/__PROJECT_NAME__.iOS.csproj" />
+  <Project Path="__PROJECT_NAME__/__PROJECT_NAME__.csproj" />
 </Solution>

--- a/templates/Console/ConsoleApp/.template.config/template.json
+++ b/templates/Console/ConsoleApp/.template.config/template.json
@@ -34,6 +34,12 @@
     }
   },
   "symbols":{
+    "projectName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "identity",
+      "replaces": "__PROJECT_NAME__"
+    },
     "createdDate": {
       "type": "generated",
       "generator": "now",

--- a/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
+++ b/templates/Console/ConsoleApp/ConsoleApp.Tests/ConsoleApp.Tests.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ConsoleApp\ConsoleApp.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 
 <!--#if (tests == "xunit")-->

--- a/templates/Console/ConsoleApp/ConsoleApp.sln
+++ b/templates/Console/ConsoleApp/ConsoleApp.sln
@@ -3,10 +3,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "ConsoleApp\ConsoleApp.csproj", "{55D459AD-9D92-4A4A-ADAB-D0143BA39451}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp", "__PROJECT_NAME__\__PROJECT_NAME__.csproj", "{55D459AD-9D92-4A4A-ADAB-D0143BA39451}"
 EndProject
 //#if (!noTests)
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp.Tests", "ConsoleApp.Tests\ConsoleApp.Tests.csproj", "{E0A57BAE-FFD5-46A6-9A93-33DF9195362B}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ConsoleApp.Tests", "__PROJECT_NAME__.Tests\__PROJECT_NAME__.Tests.csproj", "{E0A57BAE-FFD5-46A6-9A93-33DF9195362B}"
 EndProject
 //#endif
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D88D7F20-19C5-42B4-8561-874CC78B134A}"

--- a/templates/Console/ConsoleApp/ConsoleApp.slnx
+++ b/templates/Console/ConsoleApp/ConsoleApp.slnx
@@ -24,8 +24,8 @@
     <File Path=".devops/build-and-test.yml" />
   </Folder>
 <!--#endif-->
-  <Project Path="ConsoleApp/ConsoleApp.csproj" />
+  <Project Path="__PROJECT_NAME__/__PROJECT_NAME__.csproj" />
 <!--#if (!noTests)-->
-  <Project Path="ConsoleApp.Tests/ConsoleApp.Tests.csproj" />
+  <Project Path="__PROJECT_NAME__.Tests/__PROJECT_NAME__.Tests.csproj" />
 <!--#endif-->
 </Solution>

--- a/templates/Library/NuGet/.template.config/template.json
+++ b/templates/Library/NuGet/.template.config/template.json
@@ -78,6 +78,12 @@
     }
   },
   "symbols":{
+    "projectName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "identity",
+      "replaces": "__PROJECT_NAME__"
+    },
     "createdDate": {
       "type": "generated",
       "generator": "now",

--- a/templates/Library/NuGet/NuGetLib.Tests/NuGetLib.Tests.csproj
+++ b/templates/Library/NuGet/NuGetLib.Tests/NuGetLib.Tests.csproj
@@ -39,7 +39,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\NuGetLib\NuGetLib.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 
 <!--#if (tests == "xunit")-->

--- a/templates/Library/NuGet/NuGetLib.sln
+++ b/templates/Library/NuGet/NuGetLib.sln
@@ -3,10 +3,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib", "NuGetLib\NuGetLib.csproj", "{A87CB29C-0A36-423F-B9B6-43053906A3CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib", "__PROJECT_NAME__\__PROJECT_NAME__.csproj", "{A87CB29C-0A36-423F-B9B6-43053906A3CC}"
 EndProject
 //#if (!noTests)
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib.Tests", "NuGetLib.Tests\NuGetLib.Tests.csproj", "{DF8F9490-887C-489E-AFE0-99518CC49ECF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NuGetLib.Tests", "__PROJECT_NAME__.Tests\__PROJECT_NAME__.Tests.csproj", "{DF8F9490-887C-489E-AFE0-99518CC49ECF}"
 EndProject
 //#endif
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{33332FBD-7EFF-4A3D-8691-21BF50B245A7}"

--- a/templates/Library/NuGet/NuGetLib.slnx
+++ b/templates/Library/NuGet/NuGetLib.slnx
@@ -24,8 +24,8 @@
     <File Path=".devops/build-and-deploy.yml" />
   </Folder>
 <!--#endif-->
-  <Project Path="NuGetLib/NuGetLib.csproj" />
+  <Project Path="__PROJECT_NAME__/__PROJECT_NAME__.csproj" />
 <!--#if (!noTests)-->
-  <Project Path="NuGetLib.Tests/NuGetLib.Tests.csproj" />
+  <Project Path="__PROJECT_NAME__.Tests/__PROJECT_NAME__.Tests.csproj" />
 <!--#endif-->
 </Solution>

--- a/templates/WPF/WpfApp/.template.config/template.json
+++ b/templates/WPF/WpfApp/.template.config/template.json
@@ -40,6 +40,12 @@
     }
   },
   "symbols":{
+    "projectName": {
+      "type": "derived",
+      "valueSource": "name",
+      "valueTransform": "identity",
+      "replaces": "__PROJECT_NAME__"
+    },
     "user_secrets_id":{
       "type": "generated",
       "generator": "guid",

--- a/templates/WPF/WpfApp/WpfApp.Tests/WpfApp.Tests.csproj
+++ b/templates/WPF/WpfApp/WpfApp.Tests/WpfApp.Tests.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\WpfApp\WpfApp.csproj" />
+    <ProjectReference Include="..\__PROJECT_NAME__\__PROJECT_NAME__.csproj" />
   </ItemGroup>
 
 <!--#if (tests == "xunit")-->

--- a/templates/WPF/WpfApp/WpfApp.sln
+++ b/templates/WPF/WpfApp/WpfApp.sln
@@ -3,10 +3,10 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.5.33103.201
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfApp", "WpfApp\WpfApp.csproj", "{5DE76ED2-C96F-4D5B-85FF-5BC9850C11AF}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfApp", "__PROJECT_NAME__\__PROJECT_NAME__.csproj", "{5DE76ED2-C96F-4D5B-85FF-5BC9850C11AF}"
 EndProject
 //#if (!noTests)
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfApp.Tests", "WpfApp.Tests\WpfApp.Tests.csproj", "{75C75A76-E608-41BB-AEC2-80A1C95B7B62}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "WpfApp.Tests", "__PROJECT_NAME__.Tests\__PROJECT_NAME__.Tests.csproj", "{75C75A76-E608-41BB-AEC2-80A1C95B7B62}"
 EndProject
 //#endif
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{50AAD861-2EF1-4EAB-80EB-20FECB15232C}"

--- a/templates/WPF/WpfApp/WpfApp.slnx
+++ b/templates/WPF/WpfApp/WpfApp.slnx
@@ -25,8 +25,8 @@
     <File Path=".devops/build-app.yml" />
   </Folder>
 <!--#endif-->
-  <Project Path="WpfApp/WpfApp.csproj" />
+  <Project Path="__PROJECT_NAME__/__PROJECT_NAME__.csproj" />
 <!--#if (!noTests)-->
-  <Project Path="WpfApp.Tests/WpfApp.Tests.csproj" />
+  <Project Path="__PROJECT_NAME__.Tests/__PROJECT_NAME__.Tests.csproj" />
 <!--#endif-->
 </Solution>

--- a/templates/WPF/WpfApp/WpfApp/WpfApp.csproj
+++ b/templates/WPF/WpfApp/WpfApp/WpfApp.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net10.0-windows</TargetFramework>
+    <RootNamespace>WpfApp</RootNamespace>
 
     <UseWPF>true</UseWPF>
     <StartupObject>WpfApp.App</StartupObject>


### PR DESCRIPTION
## Problem

When creating a project with a hyphenated name (e.g., `dotnet new keboo.console -n my-app`), the dotnet templating engine's default `sourceName` replacement converts hyphens to underscores via its "safe form" -- so `my-app` becomes `my_app` in `.slnx`, `.sln`, `ProjectReference` paths, and CI configs. This produces broken references that fail to restore/build.

## Solution

Add a `derived` identity symbol (`projectName`) to each template's `template.json` that replaces a `__PROJECT_NAME__` placeholder with the exact user-supplied name, preserving hyphens. Only path-bearing references are updated; namespaces and type names continue to use the safe (underscore) form so C# identifiers remain valid.

```json
"projectName": {
  "type": "derived",
  "valueSource": "name",
  "valueTransform": "identity",
  "replaces": "__PROJECT_NAME__"
}
```

## Changes

All 5 templates updated with surgical path-only substitutions:

- **Console, WPF, Library/NuGet, Avalonia** -- `.slnx`, `.sln`, `*.Tests.csproj` `ProjectReference` paths, and multi-platform `.csproj` files (Avalonia)
- **WPF** -- added explicit `<RootNamespace>WpfApp</RootNamespace>` to prevent MC6029 XAML compile error when the project name contains hyphens (hyphens are invalid CLR namespace identifiers)
- **Aspire/ReactApp** -- the most surface area: `SpaRoot`, `AddJavaScriptApp(...)` relative path arg, EF CLI `--startup-project`/`--project` args in `Resources.cs`, `.aspire/settings.json`, `dependabot.yml`, and CI workflow `working-directory` / step paths
- **CI pipeline** (`.github/workflows/build.yml`) -- all `dotnet new keboo.*` invocations now pass a hyphenated `-n` argument (`my-console-app`, `my-wpf-app`, `my-lib`, `my-avalonia-app`) so the fix is exercised on every run

Fixes #514