### PR TITLE
Fix Aspire ReactApp setup script errors

### DIFF
--- a/templates/Aspire/ReactApp/Setup.ps1
+++ b/templates/Aspire/ReactApp/Setup.ps1
@@ -326,6 +326,7 @@ function Create-TerraformBackendStorage {
             --min-tls-version TLS1_2 `
             --allow-blob-public-access false `
             --https-only true `
+            --only-show-errors `
             --output none
 
         if ($LASTEXITCODE -ne 0) {
@@ -665,7 +666,7 @@ Write-Host "------------------------------------------------------" -ForegroundC
 $infraDir = Join-Path $PSScriptRoot "Infra"
 
 # Generate service_principals.tf in prod/
-$spTfPath = Join-Path $infraDir "prod" "service_principals.tf"
+$spTfPath = Join-Path (Join-Path $infraDir "prod") "service_principals.tf"
 $infraDisplayName = if ($infraApp) { $infraApp.DisplayName } else { "${AppName}Infra" }
 
 Generate-ServicePrincipalsTerraform `


### PR DESCRIPTION
This fixes two setup-script issues in the Aspire ReactApp template that can block new repo initialization.

## What changed
- corrected the `Join-Path` call used to generate `Infra\prod\service_principals.tf`, which was passing an invalid positional argument and causing Setup.ps1 to fail during Terraform file generation
- added `--only-show-errors` to the storage account creation command so the Azure CLI retired-TLS warning is suppressed while the script still explicitly enforces `--min-tls-version TLS1_2`

## Notes
This only changes the template script, so newly generated repos get the fix automatically.