### PR TITLE
Update TUnit and conditionally include test packages

### DIFF
--- a/templates/Library/NuGet/Directory.Packages.props
+++ b/templates/Library/NuGet/Directory.Packages.props
@@ -24,9 +24,13 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="10.0.300" />
     <PackageVersion Include="Moq" Version="4.20.72" />
     <PackageVersion Include="Moq.AutoMock" Version="4.0.2" />
-    <PackageVersion Include="TUnit" Version="1.45.29" />
-    <PackageVersion Include="TUnit.Assertions" Version="1.45.29" />
-    <PackageVersion Include="TUnit.Engine" Version="1.45.29" />
+<!--#if (tests == "tunit")-->
+    <PackageVersion Include="TUnit" Version="1.53.0" />
+    <PackageVersion Include="TUnit.Assertions" Version="1.53.0" />
+    <PackageVersion Include="TUnit.Engine" Version="1.53.0" />
+<!--#endif-->
+<!--#if (tests == "xunit")-->
     <PackageVersion Include="xunit.v3.mtp-v2" Version="3.2.2" />
+<!--#endif-->
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Update TUnit to version 1.53.0 and wrap test dependencies in conditional template logic to include only the relevant packages based on the selected testing framework.
