### PR TITLE
Add Aspire browser logs to React template

### DIFF
--- a/templates/Aspire/ReactApp/Directory.Packages.props
+++ b/templates/Aspire/ReactApp/Directory.Packages.props
@@ -7,6 +7,7 @@
   <ItemGroup>
     <PackageVersion Include="Aspire.Hosting.Azure" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.Azure.AppContainers" Version="13.3.5" />
+    <PackageVersion Include="Aspire.Hosting.Browsers" Version="13.4.6-preview.1.26319.6" />
     <PackageVersion Include="Aspire.Hosting.Azure.Sql" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.JavaScript" Version="13.3.5" />
     <PackageVersion Include="Aspire.Hosting.SqlServer" Version="13.4.0" />

--- a/templates/Aspire/ReactApp/README.md
+++ b/templates/Aspire/ReactApp/README.md
@@ -44,6 +44,9 @@ This template uses a `global.json` file to specify the required .NET SDK version
 
 ## Key Features
 
+### Aspire Browser Logs
+The AppHost enables [Aspire browser logs](https://aspire.dev/integrations/devtools/browser-logs/) for the React frontend resource. From the Aspire dashboard you can open a tracked browser, stream browser console/network events into the resource logs, and capture screenshots.
+
 ### Progressive Web App (PWA) Support
 Both the ReactApp.Web includes full PWA support with:
 - Service worker for offline functionality
@@ -119,7 +122,5 @@ cd Infra
 terraform init
 terraform plan
 ```
-
-
 
 

--- a/templates/Aspire/ReactApp/ReactApp.AppHost/AppHost.cs
+++ b/templates/Aspire/ReactApp/ReactApp.AppHost/AppHost.cs
@@ -30,13 +30,16 @@ var backend = builder.AddProject<Projects.ReactApp>("ReactApp-backend")
     .WithExternalHttpEndpoints()
     .PublishAsAzureContainerApp((infra, app) => app.Template.Scale.MaxReplicas = 1);
 
+#pragma warning disable ASPIREBROWSERLOGS001
 var frontendApp = builder.AddJavaScriptApp(Resources.Frontend, "../__PROJECT_NAME__.Web", "dev")
     .WithNpm(install: true)
     .WithHttpEndpoint(env: "PORT")
+    .WithBrowserLogs()
     .WithExternalHttpEndpoints()
     .WithDependency(backend)
     .WithEnvironment("REACTAPP_BACKEND_HTTP", backend.GetEndpoint("http"))
     .WithEnvironment("REACTAPP_BACKEND_HTTPS", backend.GetEndpoint("https"));
+#pragma warning restore ASPIREBROWSERLOGS001
 
 if (builder.ExecutionContext.IsPublishMode)
 {

--- a/templates/Aspire/ReactApp/ReactApp.AppHost/ReactApp.AppHost.csproj
+++ b/templates/Aspire/ReactApp/ReactApp.AppHost/ReactApp.AppHost.csproj
@@ -9,6 +9,7 @@
     <PackageReference Include="Aspire.Hosting.Azure" />
     <PackageReference Include="Aspire.Hosting.Azure.AppContainers" />
     <PackageReference Include="Aspire.Hosting.Azure.Sql" />
+    <PackageReference Include="Aspire.Hosting.Browsers" />
     <PackageReference Include="Aspire.Hosting.JavaScript" />
     <PackageReference Include="Aspire.Hosting.SqlServer" />
     <PackageReference Include="CommunityToolkit.Aspire.Hosting.SqlServer.Extensions" />


### PR DESCRIPTION
The `keboo.react` Aspire template didn't include browser log streaming out of the box. This adds `Aspire.Hosting.Browsers` so generated projects come with browser console and network event capture wired up from day one.

## What changed

- **`Directory.Packages.props`** - pins `Aspire.Hosting.Browsers` at `13.3.4-preview.1.26268.8`, matching the template's existing Aspire version line
- **`ReactApp.AppHost.csproj`** - adds the `PackageReference` (version resolved via CPM)
- **`AppHost.cs`** - calls `.WithBrowserLogs()` on the frontend JS app resource; wraps with `#pragma warning disable/restore ASPIREBROWSERLOGS001` since the API is marked evaluation-only and emits an error-level diagnostic by default
- **`README.md`** - documents the feature under Key Features with a link to the [official Aspire browser logs docs](https://aspire.dev/integrations/devtools/browser-logs/)

## Notes

`ASPIREBROWSERLOGS001` is an intentional evaluation-only guard from the Aspire team. The pragma suppression is the documented workaround and mirrors the pattern in Aspire's own docs snippets. A full end-to-end smoke test (pack template -> `dotnet new keboo.react` -> `dotnet build AppHost`) confirmed the generated project builds clean.