### PR TITLE
Add --github-packages parameter to NuGet template

### DIFF
--- a/templates/Library/NuGet/.devops/build-and-deploy.yml
+++ b/templates/Library/NuGet/.devops/build-and-deploy.yml
@@ -95,15 +95,27 @@ stages:
               publishLocation: 'Container'
 
   - stage: Deploy
+#if (github-packages)
+    displayName: 'Deploy to GitHub Packages'
+#else
     displayName: 'Deploy to NuGet.org'
+#endif
     dependsOn: Build
     condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
     jobs:
       - deployment: DeployNuGet
+#if (github-packages)
+        displayName: 'Push to GitHub Packages'
+#else
         displayName: 'Push to NuGet.org'
+#endif
         pool:
           vmImage: 'ubuntu-latest'
+#if (github-packages)
+        environment: 'github-packages'
+#else
         environment: 'nuget-org'
+#endif
         strategy:
           runOnce:
             deploy:
@@ -111,6 +123,17 @@ stages:
                 - download: current
                   artifact: NuGet
 
+#if (github-packages)
+                # Configure these pipeline variables before use:
+                # - GITHUB_PACKAGES_OWNER: GitHub owner (org or user)
+                # - GITHUB_PACKAGES_TOKEN: Secret PAT with write:packages scope
+                - task: PowerShell@2
+                  displayName: 'Push NuGet Package to GitHub Packages'
+                  inputs:
+                    targetType: 'inline'
+                    script: |
+                      dotnet nuget push "$(Pipeline.Workspace)/NuGet/*.nupkg" --source "https://nuget.pkg.github.com/$(GITHUB_PACKAGES_OWNER)/index.json" --api-key "$(GITHUB_PACKAGES_TOKEN)" --skip-duplicate
+#else
                 - task: NuGetCommand@2
                   displayName: 'Push NuGet Package'
                   inputs:
@@ -118,3 +141,4 @@ stages:
                     packagesToPush: '$(Pipeline.Workspace)/NuGet/**/*.nupkg;!$(Pipeline.Workspace)/NuGet/**/*.symbols.nupkg'
                     nuGetFeedType: 'external'
                     publishFeedCredentials: 'NuGet.org'
+#endif

--- a/templates/Library/NuGet/.github/workflows/build-and-deploy.yml
+++ b/templates/Library/NuGet/.github/workflows/build-and-deploy.yml
@@ -87,17 +87,29 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     runs-on: ubuntu-latest
     needs: build
-    
+
+#if (github-packages)
+    permissions:
+      packages: write
+#else
     # Required for Trusted Publishing: allows GitHub to issue OIDC tokens for this job
     # This enables secure, keyless authentication with NuGet.org
     permissions:
       id-token: write
-    
+#endif
+
     steps:
       - name: Download artifact from build job
         uses: actions/download-artifact@v8
         with:
           name: NuGet
+
+#if (github-packages)
+      - name: Push NuGet package to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: dotnet nuget push ${{ github.workspace }}/*nupkg --source https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json --api-key ${{ env.GITHUB_TOKEN }} --skip-duplicate
+#else
 
       # ====================================================================================
       # OPTION 1: Trusted Publishing (RECOMMENDED - Default)
@@ -152,3 +164,4 @@ jobs:
 
       # - name: Push NuGet (API Key)
       #   run: dotnet nuget push ${{ github.workspace }}/*nupkg --source https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+#endif

--- a/templates/Library/NuGet/.template.config/template.json
+++ b/templates/Library/NuGet/.template.config/template.json
@@ -178,6 +178,12 @@
       "defaultValue": "github",
       "description": "The CI/CD provider to use"
     },
+    "github-packages": {
+      "type": "parameter",
+      "dataType": "bool",
+      "defaultValue": "false",
+      "description": "Publish packages to GitHub Packages instead of NuGet.org"
+    },
     "useGitHub": {
       "type": "computed",
       "value": "(pipeline == \"github\")"

--- a/templates/Library/NuGet/README.md
+++ b/templates/Library/NuGet/README.md
@@ -19,6 +19,7 @@ The generated projects are restored automatically after creation. Use `--skipRes
 | `--skipRestore` | Skip the automatic restore after template creation | `false` |
 | `--no-sln` | Do not include a solution file | `false` |
 | `--pipeline` | CI/CD provider to use. Options: `github`, `azuredevops`, `none` | `github` |
+| `--github-packages` | Publish packages to GitHub Packages instead of NuGet.org | `false` |
 | `--sln` | Use legacy .sln format instead of .slnx format | `false` |
 | `--tests` | Testing framework to use. Options: `xunit`, `mstest`, `tunit`, `none` | `tunit` |
 
@@ -30,6 +31,11 @@ The generated projects are restored automatically after creation. Use `--skipRes
 **Example with no CI/CD pipeline:**
 ```cli
 > dotnet new keboo.nuget --pipeline none
+```
+
+**Example publishing to GitHub Packages:**
+```cli
+> dotnet new keboo.nuget --github-packages true
 ```
 
 **Example with legacy .sln format:**
@@ -66,7 +72,11 @@ This template uses a `global.json` file to specify the required .NET SDK version
 [Docs](https://learn.microsoft.com/nuget/consume-packages/package-source-mapping?WT.mc_id=DT-MVP-5003472)
 
 ### GitHub Actions / Azure DevOps Pipeline
-Build, test, pack, and deploy to NuGet.org included. Use `--pipeline` parameter to choose between GitHub Actions (default) or Azure DevOps Pipelines.
+Build, test, pack, and deploy pipelines are included. By default, package publishing targets NuGet.org; set `--github-packages true` to switch publishing to GitHub Packages instead.
+
+When using `--github-packages true`:
+- GitHub Actions publishes with `GITHUB_TOKEN`.
+- Azure DevOps expects `GITHUB_PACKAGES_OWNER` and secret `GITHUB_PACKAGES_TOKEN` pipeline variables.
 
 ### Solution File Format (slnx)
 By default, this template uses the new `.slnx` (XML-based solution) format introduced in .NET 9. This modern format is more maintainable and easier to version control compared to the legacy `.sln` format.


### PR DESCRIPTION
Introduces a new --github-packages parameter to allow scaffolding projects configured to publish packages to GitHub Packages instead of NuGet.org. This update modifies the Azure DevOps and GitHub Actions pipelines to support conditional publishing logic and updates the template documentation accordingly.
