### PR TITLE
Rename Aspire Template Short Name to `keboo.aspire`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -734,7 +734,7 @@ jobs:
           dotnet new install $(Get-ChildItem -Path "Keboo.Dotnet.Templates.*.nupkg").Name
           mkdir TestAspire
           Push-Location TestAspire
-          dotnet new keboo.react -n "${{ matrix.app-name }}" ${{ matrix.template-args }}
+          dotnet new keboo.aspire -n "${{ matrix.app-name }}" ${{ matrix.template-args }}
 
       - name: Verify frontend scaffold
         run: |

--- a/Templates.csproj
+++ b/Templates.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageType>Template</PackageType>
-    <PackageVersion>1.14.1</PackageVersion>
+    <PackageVersion>2.0.0</PackageVersion>
     <PackageId>Keboo.Dotnet.Templates</PackageId>
     <Title>Keboo's .NET Templates</Title>
     <Authors>Keboo</Authors>
@@ -13,7 +13,7 @@
     <RepositoryUrl>https://github.com/Keboo/DotnetTemplates</RepositoryUrl>
     <PackageProjectUrl>https://github.com/Keboo/DotnetTemplates</PackageProjectUrl>
     <RepositoryType>git</RepositoryType>
-    <PackageReleaseNotes>Adds Vue frontend support to the Aspire template and improves package discoverability metadata.</PackageReleaseNotes>
+    <PackageReleaseNotes>Renamed the Aspire template short name from 'keboo.react' to 'keboo.aspire' (breaking change).</PackageReleaseNotes>
     <PackageIcon>NuGetIcon.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <LocalizeTemplates>false</LocalizeTemplates>

--- a/templates/Aspire/AspireApp/.template.config/template.json
+++ b/templates/Aspire/AspireApp/.template.config/template.json
@@ -7,10 +7,10 @@
     "React",
     "Vue"
   ],
-  "identity": "Keboo.Aspire.React.Solution",
+  "identity": "Keboo.Aspire.Solution",
   "name": "Keboo Aspire Web Application",
   "description": "Creates a .NET Aspire solution with a React or Vue frontend, backend services, tests, and Azure deployment assets.",
-  "shortName": "keboo.react",
+  "shortName": "keboo.aspire",
   "icon": "favicon.ico",
   "tags": {
     "language": "C#",

--- a/templates/Aspire/AspireApp/README.md
+++ b/templates/Aspire/AspireApp/README.md
@@ -6,7 +6,7 @@ This template creates a [.NET Aspire](https://learn.microsoft.com/dotnet/aspire/
 Create a new app in your current directory by running.
 
 ```cli
-> dotnet new keboo.react
+> dotnet new keboo.aspire
 ```
 
 ### Parameters
@@ -22,22 +22,22 @@ This template includes TUnit-based test projects by default.
 
 **Example with Vue frontend:**
 ```cli
-> dotnet new keboo.react --frontend vue
+> dotnet new keboo.aspire --frontend vue
 ```
 
 **Example with Azure DevOps:**
 ```cli
-> dotnet new keboo.react --pipeline azuredevops
+> dotnet new keboo.aspire --pipeline azuredevops
 ```
 
 **Example with no CI/CD pipeline:**
 ```cli
-> dotnet new keboo.react --pipeline none
+> dotnet new keboo.aspire --pipeline none
 ```
 
 **Example with legacy .sln format:**
 ```cli
-> dotnet new keboo.react --sln true
+> dotnet new keboo.aspire --sln true
 ```
 
 


### PR DESCRIPTION
The previous short name, `keboo.react`, was misleading after the addition of Vue frontend support. The new name, `keboo.aspire`, more accurately represents the template's multi-frontend capabilities.

This change introduces a breaking change for existing users and is accompanied by a major version bump to `2.0.0`.
