### PR TITLE
Fix missing Azure SQL auth package and pin SqlClient in Aspire template

### DIFF
--- a/templates/Aspire/AspireApp/AspireApp.Data/AspireApp.Data.csproj
+++ b/templates/Aspire/AspireApp/AspireApp.Data/AspireApp.Data.csproj
@@ -13,5 +13,15 @@
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <!-- Microsoft.EntityFrameworkCore.SqlServer only requires Microsoft.Data.SqlClient
+         >= 6.1.1 transitively. Pin it explicitly to the same release line as
+         Extensions.Azure below to avoid an AmbiguousMatchException in
+         SqlAuthenticationProviderManager caused by mismatched versions. -->
+    <PackageReference Include="Microsoft.Data.SqlClient" />
+    <!-- Required for "Authentication=Active Directory Default" / Entra ID connection strings.
+         Microsoft.Data.SqlClient 6+ moved Azure AD authentication providers into this
+         separate package; without it, ActiveDirectoryDefault connections fail with
+         "Cannot find an authentication provider for 'ActiveDirectoryDefault'". -->
+    <PackageReference Include="Microsoft.Data.SqlClient.Extensions.Azure" />
   </ItemGroup>
 </Project>

--- a/templates/Aspire/AspireApp/Directory.Packages.props
+++ b/templates/Aspire/AspireApp/Directory.Packages.props
@@ -21,6 +21,7 @@
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
     <PackageVersion Include="Microsoft.AspNetCore.SpaProxy" Version="10.0.11" />
     <PackageVersion Include="Microsoft.Data.SqlClient" Version="7.0.2" />
+    <PackageVersion Include="Microsoft.Data.SqlClient.Extensions.Azure" Version="7.0.2" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.11" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.11" />


### PR DESCRIPTION
## Summary
Mirrors the fix applied to SimplyBudget (Keboo/SimplyBudget#92 and #93) in this repo's Aspire template.

- **Missing package**: `Microsoft.Data.SqlClient` 6+ moved Azure AD authentication providers into a separate package, `Microsoft.Data.SqlClient.Extensions.Azure`. Without it, connections using `Authentication=Active Directory Default` fail with "Cannot find an authentication provider".
- **Version pin**: `Microsoft.EntityFrameworkCore.SqlServer` only requires `Microsoft.Data.SqlClient >= 6.1.1` transitively, which predates the Azure AD provider split and is binary-incompatible with `Microsoft.Data.SqlClient.Extensions.Azure` 7.0.2, causing an `AmbiguousMatchException` in `SqlAuthenticationProviderManager`'s static constructor. Pinning both packages to the same release line (7.0.2) resolves this.

## Changes
- `templates/Aspire/AspireApp/Directory.Packages.props`: added `PackageVersion` for `Microsoft.Data.SqlClient.Extensions.Azure` at `7.0.2`, matching the already-pinned `Microsoft.Data.SqlClient` version.
- `templates/Aspire/AspireApp/AspireApp.Data/AspireApp.Data.csproj`: added explicit `PackageReference`s for `Microsoft.Data.SqlClient` and `Microsoft.Data.SqlClient.Extensions.Azure` so the pinned versions win over the transitive reference.

## Testing
- Restored and built `AspireApp.Data.csproj` locally with .NET 10.0.400 SDK — succeeded with 0 warnings/errors and correct package resolution.