### PR TITLE
Add optional custom domain parameters to Aspire template's Terraform infra

### DIFF
--- a/templates/Aspire/AspireApp/.github/workflows/deploy-infrastructure.yml
+++ b/templates/Aspire/AspireApp/.github/workflows/deploy-infrastructure.yml
@@ -56,6 +56,8 @@ jobs:
           TF_VAR_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_INFRA }}
           TF_VAR_TENANT_ID: ${{ secrets.ARM_TENANT_ID_INFRA }}
           TF_VAR_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
+          # TF_VAR_backend_custom_domain: 'https://api.example.com' # TODO: Uncomment and set if you configure a custom domain for the backend Container App
+          # TF_VAR_frontend_custom_domain: 'https://app.example.com' # TODO: Uncomment and set if you configure a custom domain for the frontend Static Web App
 
       - name: Upload Terraform Plan
         uses: actions/upload-artifact@v7
@@ -116,3 +118,5 @@ jobs:
           TF_VAR_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID_INFRA }}
           TF_VAR_TENANT_ID: ${{ secrets.ARM_TENANT_ID_INFRA }}
           TF_VAR_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID_INFRA }}
+          # TF_VAR_backend_custom_domain: 'https://api.example.com' # TODO: Uncomment and set if you configure a custom domain for the backend Container App
+          # TF_VAR_frontend_custom_domain: 'https://app.example.com' # TODO: Uncomment and set if you configure a custom domain for the frontend Static Web App

--- a/templates/Aspire/AspireApp/Infra/main.tf
+++ b/templates/Aspire/AspireApp/Infra/main.tf
@@ -35,5 +35,8 @@ module "prod" {
   acr_login_server = module.shared.acr_login_server
   location         = local.location
   tags             = local.default_tags
+
+  backend_custom_domain  = var.backend_custom_domain
+  frontend_custom_domain = var.frontend_custom_domain
 }
 

--- a/templates/Aspire/AspireApp/Infra/prod/main.tf
+++ b/templates/Aspire/AspireApp/Infra/prod/main.tf
@@ -4,6 +4,13 @@ locals {
     {
       "Environment" = local.environment
   })
+
+  # CORS origins the backend should accept requests from: the Static Web
+  # App's auto-generated hostname, plus the frontend custom domain when set.
+  allowed_origins = compact([
+    "https://${module.static_web_app.default_host_name}",
+    var.frontend_custom_domain,
+  ])
 }
 
 resource "azurerm_resource_group" "resource_group" {
@@ -42,14 +49,16 @@ module "backend_container_app" {
   identity_id                     = azurerm_user_assigned_identity.app_identity.id
   container_registry_login_server = var.acr_login_server
 
-  env_vars = {
+  env_vars = merge({
     AZURE_CLIENT_ID = azurerm_user_assigned_identity.app_identity.client_id
     # Aspire uses ConnectionStrings__<key> naming convention
-    ConnectionStrings__Database = module.sql.connection_string
+    ConnectionStrings__Database           = module.sql.connection_string
     APPLICATIONINSIGHTS_CONNECTION_STRING = module.application_insights.application_insights.connection_string
-    # CORS: Allow the Static Web App origin
-    AllowedOrigins__0 = "https://${module.static_web_app.default_host_name}"
-  }
+    },
+    # CORS: Allow the Static Web App origin(s). Produces AllowedOrigins__0,
+    # AllowedOrigins__1, etc. matching the .NET config array binding.
+    { for i, origin in local.allowed_origins : "AllowedOrigins__${i}" => origin }
+  )
 
   depends_on = [module.sql, module.static_web_app]
 }

--- a/templates/Aspire/AspireApp/Infra/prod/outputs.tf
+++ b/templates/Aspire/AspireApp/Infra/prod/outputs.tf
@@ -29,13 +29,13 @@ output "static_web_app_api_key" {
 }
 
 output "static_web_app_url" {
-  description = "The URL of the deployed static web app"
-  value       = "https://${module.static_web_app.default_host_name}"
+  description = "The URL of the deployed static web app. Uses the custom domain when var.frontend_custom_domain is non-empty, otherwise falls back to the auto-generated Static Web App hostname."
+  value       = var.frontend_custom_domain != "" ? var.frontend_custom_domain : "https://${module.static_web_app.default_host_name}"
 }
 
 output "backend_url" {
-  description = "The URL of the backend API"
-  value       = "https://${module.backend_container_app.fqdn}"
+  description = "The URL of the backend API. Uses the custom domain when var.backend_custom_domain is non-empty, otherwise falls back to the auto-generated Container App FQDN."
+  value       = var.backend_custom_domain != "" ? var.backend_custom_domain : "https://${module.backend_container_app.fqdn}"
 }
 
 output "applicationinsights_connection_string" {

--- a/templates/Aspire/AspireApp/Infra/prod/variables.tf
+++ b/templates/Aspire/AspireApp/Infra/prod/variables.tf
@@ -18,3 +18,15 @@ variable "tags" {
   type        = map(string)
   default     = {}
 }
+
+variable "backend_custom_domain" {
+  description = "Custom domain URL for the backend API (e.g. https://api.example.com). When set, overrides the auto-generated Container App FQDN as the backend_url output."
+  type        = string
+  default     = ""
+}
+
+variable "frontend_custom_domain" {
+  description = "Custom domain URL for the frontend Static Web App (e.g. https://app.example.com). When set, overrides the auto-generated Static Web App hostname as the static_web_app_url output, and is added as an additional allowed CORS origin on the backend."
+  type        = string
+  default     = ""
+}

--- a/templates/Aspire/AspireApp/Infra/variables.tf
+++ b/templates/Aspire/AspireApp/Infra/variables.tf
@@ -15,3 +15,15 @@ variable "SUBSCRIPTION_ID" {
   description = "Value of the subscription id to use"
   default     = ""
 }
+
+variable "backend_custom_domain" {
+  description = "Custom domain URL for the backend API (e.g. https://api.example.com). When set, overrides the auto-generated Container App FQDN as the backend_url output."
+  type        = string
+  default     = ""
+}
+
+variable "frontend_custom_domain" {
+  description = "Custom domain URL for the frontend Static Web App (e.g. https://app.example.com). When set, overrides the auto-generated Static Web App hostname as the static_web_app_url output, and is added as an additional allowed CORS origin on the backend."
+  type        = string
+  default     = ""
+}

--- a/templates/Aspire/AspireApp/README.md
+++ b/templates/Aspire/AspireApp/README.md
@@ -129,3 +129,25 @@ terraform init
 terraform plan
 ```
 
+### Custom Domains
+
+If you configure custom domains for the backend Container App and/or the
+frontend Static Web App, set the optional `backend_custom_domain` and
+`frontend_custom_domain` Terraform variables (both default to an empty
+string, which falls back to the auto-generated Azure hostnames):
+
+```bash
+terraform plan \
+  -var="backend_custom_domain=https://api.example.com" \
+  -var="frontend_custom_domain=https://app.example.com"
+```
+
+- `backend_custom_domain` overrides the `backend_url` output (used to
+  configure the frontend's API base URL at build time).
+- `frontend_custom_domain` overrides the `static_web_app_url` output and is
+  added as an additional allowed CORS origin on the backend, so requests
+  from the custom domain aren't rejected.
+
+In CI, uncomment and set the `TF_VAR_backend_custom_domain` /
+`TF_VAR_frontend_custom_domain` lines in
+`.github/workflows/deploy-infrastructure.yml`.


### PR DESCRIPTION
Adds `backend_custom_domain` and `frontend_custom_domain` optional Terraform variables (default `""`) to the Aspire app template's `Infra/` configuration:

- `backend_custom_domain` overrides the `backend_url` output (used to configure the frontend's API base URL at build time) instead of the auto-generated Container App FQDN.
- `frontend_custom_domain` overrides the `static_web_app_url` output instead of the auto-generated Static Web App hostname, and is added as an additional allowed CORS origin on the backend so requests from the custom domain aren't rejected.

Also adds commented-out `TF_VAR_backend_custom_domain` / `TF_VAR_frontend_custom_domain` TODO lines to `deploy-infrastructure.yml` (mirroring the existing `BACKEND_URL` TODO convention), and documents the new variables in the template's `README.md`.

This mirrors infra changes recently applied to a project generated from this template, where the frontend's custom domain wasn't included in the backend's CORS allow-list and `backend_url` pointed at the auto-generated Container App FQDN instead of the custom API domain.

Validated with `terraform validate` and `terraform fmt -check`.